### PR TITLE
add JGraphT

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 * [Apache Commons](http://commons.apache.org/) - Provides different general purpose functions like configuration, validation, collections, file upload or XML processing.
 * [Guava](http://code.google.com/p/guava-libraries/) - Collections, caching, primitives support, concurrency libraries, common annotations, string processing, I/O, and so forth.
 * [javatuples](http://www.javatuples.org/) - Does what it says, although the concept of tuples in general is debatable.
+* [JGraphT](http://jgrapht.org/) - A graph library that provides mathematical graph-theory objects and algorithms.
 
 ## Web Crawling
 


### PR DESCRIPTION
add JGraphT, a free Java graph library that provides mathematical graph-theory objects and algorithms.