### PR TITLE
Adding android-iconizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 
 *Everything else.*
 
+* [android-iconizer](https://github.com/rapito/android-iconizer) - GUI and CLI Tool to easily create resized copies of an Image to use as an android resource.
 * [Design Patterns](https://github.com/iluwatar/java-design-patterns) - Implementation and explanation of the most common design patterns.
 * [Jimfs](https://github.com/google/jimfs) - In-memory file system.
 * [Lanterna](https://code.google.com/p/lanterna/) - Easy console text GUI library similar to curses.


### PR DESCRIPTION
Adding [android-iconizer](https://github.com/rapito/android-iconizer) - GUI and CLI Tool to easily create resized copies of an Image to use as an android resource.