### PR TITLE
Add Feign to REST Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 *Frameworks specifically for creating RESTful services.*
 
 * [Dropwizard](https://dropwizard.github.io/dropwizard/) - Opinionated framework for setting up modern web applications, includes Jetty, Jackson, Jersey and Metrics.
+* [Feign](https://github.com/Netflix/feign) - Java to HTTP client binder inspired by Retrofit, JAXRS-2.0, and WebSocket.
 * [Jersey](https://jersey.java.net/) - JAX-RS reference implementation.
 * [RESTEasy](http://resteasy.jboss.org/) - Fully certified and portable implementation of the JAX-RS specification.
 * [Retrofit](http://square.github.io/retrofit/) - A type-safe REST client for Java.


### PR DESCRIPTION
Added Netflix's Feign library which aims to ease the building of HTTP clients.