### PR TITLE
Setting back restx ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 * [Feign](https://github.com/Netflix/feign) - Java to HTTP client binder inspired by Retrofit, JAXRS-2.0, and WebSocket.
 * [Jersey](https://jersey.java.net/) - JAX-RS reference implementation.
 * [RESTEasy](http://resteasy.jboss.org/) - Fully certified and portable implementation of the JAX-RS specification.
+* [RestX](http://restx.io) - Opinionated framework based one annotation processor, providing support for REST endpoint, type safe DI, hot compile/reload, API doc, metrics, specs-oriented endpoint testing.
 * [Retrofit](http://square.github.io/retrofit/) - A type-safe REST client for Java.
 * [Spark](http://www.sparkjava.com/) - A Sinatra inspired framework for java.
 * [Swagger](https://helloreverb.com/developers/swagger) - Swagger is a specification and complete framework implementation for describing, producing, consuming, and visualizing RESTful web services.


### PR DESCRIPTION
[Restx](http://restx.io) was initially integrated with PR #29 from @simonbasle and merged by @akullpp

This addition was rolled back in adb74f4 without real justification in commit message by @akullpp :(

I think `restx` (author : @xhanin) follows what is described in `contributing.md` as it is (as far as I know) absolutely unique in its approach and function (don't know any rest framework based on annotation processor)

Plus it as some features I didn't see elsewhere :
- Annotation processing everywhere (=no reflection => great perfs)
- Type safe DI (we have others like dagger, but I don't know of fully integrated in a web framework)
- API docs far richer than swagger ones
- Specs-oriented endpoint testing (example [here](https://github.com/restx/restx/blob/master/restx-server-testing/src/test/resources/specs/sessions/should_disconnection_be_successful.spec.yaml))