### PR TITLE
Add jmockit to testing frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 * [AssertJ](http://joel-costigliola.github.io/assertj/) - Fluent assertions that improve readability.
 * [Hamcrest](http://hamcrest.org/JavaHamcrest/) - Matchers that can be combined to create flexible expressions of intent.
 * [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Microbenchmarking tool for the JVM.
+* [JMockit](http://jmockit.org/) - The Mock Anything Toolkit for Java, mocks static, final methods and more.
 * [JUnit](http://junit.org/) - Common testing framework.
 * [Mockito](http://code.google.com/p/mockito/) - Creation of test double objects in automated unit tests for the purpose of TDD or BDD.
 * [Selenide](http://selenide.org/) - Concise API around Selenium to write stable and readable UI tests.


### PR DESCRIPTION
JMockit can mock anything like static and final methods, constructors and futures. This makes JMockit very useful for testing legacy code, but personally I like the api more than mockitos api.