### PR TITLE
Add native section with JNA

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
     - [Machine Learning](#machine-learning)
     - [Messaging](#messaging)
     - [Miscellaneous](#miscellaneous)
+    - [Native](#native)
     - [Natural Language Processing](#natural-language-processing)
     - [Networking](#networking)
     - [ORM](#orm)
@@ -271,6 +272,11 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 * [Metrics](http://metrics.codahale.com/) - Create your own metrics or add them for supported frameworks, then expose them via JMX or HTTP, or send them to a database.
 * [OpenRefine](http://openrefine.org/) -  Tool for working with messy data: cleaning, transforming, extending it with web services and linking it to databases.
 * [RoboVM](http://www.robovm.org/) - Commercial framework with a free trial to write native iOS apps in Java.
+
+## Native
+*For working with platform-specific native libraries*
+
+* [JNA](https://github.com/twall/jna) - Work with native libraries without writing JNI. Also provides interfaces to common system libraries. 
 
 ## Natural Language Processing
 


### PR DESCRIPTION
[JNA](https://github.com/twall/jna) (Java Native Access) is a popular library for interacting with native libraries.  There are other libraries for dealing with native libraries ([BridJ](https://github.com/nativelibs4java/BridJ), [JACOB](http://sourceforge.net/projects/jacob-project/) for Windows COM, [JNAerator](https://github.com/nativelibs4java/JNAerator)), so I feel like native is worthy of a new section.  However, we can also add JNA to Miscellaneous if you like.  
Thanks for maintaining this list.