### PR TITLE
Add Fugue: Functional extensions (Guava, Java 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A curated list of awesome Java frameworks, libraries and software. Inspired by o
 
 * [Cyclops](https://github.com/aol/cyclops) - Monad and stream utils, comprehensions, pattern matching, trampolines, etc for Java 8.
 * [Functional Java](http://www.functionaljava.org) - Implements numerous basic and advanced programming abstractions that assist composition oriented development.
+* [Fugue](https://bitbucket.org/atlassian/fugue) - Functional extensions to Guava and Java 8.
 * [Javaslang](http://javaslang.com) - Functional component library built for Java 8+ that provides persistent data types and functional control structures.
 * [jOOλ](https://github.com/jOOQ/jOOL) - An extension to Java 8 which aims to fix gaps in lambda, providing numerous missing types and a rich set of sequential Stream API additions.
 


### PR DESCRIPTION
Nice, lightweight, well-tested, functional programming library to complement Guava (2.x serie) or Java 8 (3.x serie).
In particular it provides Option and Either types similar to the Scala library as well as a Pair.
By Atlassian and contributors.