### PR TITLE
Added Kamon under Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 * [AppDynamics](http://www.appdynamics.com/) - Commercial performance monitor.
 * [JavaMelody](https://github.com/javamelody/javamelody) - Open-source performance monitoring and profiling.
+* [Kamon](http://www.kamon.io/) - Open-source tool for monitoring applications running on the JVM.
 * [New Relic](http://newrelic.com/) - Commercial performance monitor.
 * [Takipi](https://www.takipi.com/) - Commercial in-production error monitoring and debugging.
 


### PR DESCRIPTION
Added Kamon under Monitoring. Open-source tool for monitoring applications running on the JVM:
http://kamon.io/introduction/get-started/