### PR TITLE
Added JGiven

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Cucumber](https://github.com/cucumber/cucumber-jvm) - BDD testing framework.
 * [Gatling](http://gatling.io/) - Load testing tool designed for ease of use, maintainability and high performance.
 * [Hamcrest](http://hamcrest.org/JavaHamcrest/) - Matchers that can be combined to create flexible expressions of intent.
+* [JGiven](http://jgiven.org) - Developer-friendly BDD testing framework compatible with JUnit and TestNG
 * [JMockit](http://jmockit.org/) - Mocks static, final methods and more.
 * [JUnit](http://junit.org/) - Common testing framework.
 * [Mockito](https://github.com/mockito/mockito) - Creation of test double objects in automated unit tests for the purpose of TDD or BDD.


### PR DESCRIPTION
JGiven is a developer-friendly BDD testing framework that is compatible with JUnit and TestNG. 

It is not yet widely known in the Java community, but it is unique because scenarios are written directly in Java code instead of text files.

Disclaimer: I am the author of JGiven