### PR TITLE
Add Capsule

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Tools which handle the distribution of applications in native formats.*
 
 * [Bintray](https://bintray.com/) - Version control for binaries which handles the publishing. Can also be used with Maven or Gradle and has a free plan for open-source software or several business plans.
+* [Capsule](http://capsule.io) - Simple and powerful packaging and deployment. A fat JAR on steroids or a "Docker for Java" that supports JVM-optimized containers.
 * [Central Repository](http://search.maven.org/) - Largest binary component repository available as a free service to the open-source community. Default used by Apache Maven and available in all other build tools.
 * [IzPack](http://izpack.org/) - Setup authoring tool for cross-platform deployments.
 * [JitPack](https://jitpack.io/) - Easy to use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.


### PR DESCRIPTION
Added Capsule, a packaging and deployment solution for JVM apps with support for containers. A “Docker for Java”.