### PR TITLE
fixed the link to Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [RestX](http://restx.io) - Framework based on annotation processing and compile-time source generation.
 * [Retrofit](http://square.github.io/retrofit/) - Type-safe REST client.
 * [Spark](http://www.sparkjava.com/) - Sinatra inspired framework.
-* [Swagger](https://helloreverb.com/developers/swagger) - Swagger is a specification and complete framework implementation for describing, producing, consuming, and visualizing RESTful web services.
+* [Swagger](http://swagger.io/) - Swagger is a specification and complete framework implementation for describing, producing, consuming, and visualizing RESTful web services.
 
 ## Science
 


### PR DESCRIPTION
Swagger link changed from [https://helloreverb.com/developers/swagger](https://helloreverb.com/developers/swagger) to [http://swagger.io/](http://swagger.io/)