### PR TITLE
add moco, a concise stub and mock web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [WireMock](http://wiremock.org/) - Stubbs and mocks web services.
 * [Moco](https://github.com/dreamhead/moco) - Concise web services for stubbs and mocks, Duke's Choice Award 2013.
 
-
 ## Utility
 
 *Libraries which provide general utility functions.*

--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Truth](https://github.com/google/truth) - Google's assertion and proposition framework.
 * [Unitils](http://www.unitils.org/) - Modular testing library for unit and integration testing.
 * [WireMock](http://wiremock.org/) - Stubbs and mocks web services.
+* [Moco](https://github.com/dreamhead/moco) - Concise web services for stubbs and mocks, Duke's Choice Award 2013.
+
 
 ## Utility
 


### PR DESCRIPTION
similar as wiremock, but it is a lot more concise and straightforward to use.