### PR TITLE
Adding Machine Learning library JSAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [DeepDive](http://deepdive.stanford.edu) - Creates structured information from unstructured data and integrates it into an existing database.
 * [Deeplearning4j](http://deeplearning4j.org/) - Distributed and multi-threaded deep learning library.
 * [H2O](http://0xdata.com/) - Analytics engine for statistics over big data.
-* [JSAT](https://github.com/EdwardRaff/JSAT) -  Numerous Machine Learning algorithms for pre-processing, classification, regression, and clustering. Some algorithms support mult-threaded execution. 
+* [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution.
 * [Weka](http://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization.
 
 ## Messaging

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [DeepDive](http://deepdive.stanford.edu) - Creates structured information from unstructured data and integrates it into an existing database.
 * [Deeplearning4j](http://deeplearning4j.org/) - Distributed and multi-threaded deep learning library.
 * [H2O](http://0xdata.com/) - Analytics engine for statistics over big data.
-* [JSAT](https://github.com/EdwardRaff/JSAT) -  Numerous Machine Learning algorithms for pre-processing, classification, regression, and clustering. Some algorithms suport mult-threaded execution. 
+* [JSAT](https://github.com/EdwardRaff/JSAT) -  Numerous Machine Learning algorithms for pre-processing, classification, regression, and clustering. Some algorithms support mult-threaded execution. 
 * [Weka](http://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization.
 
 ## Messaging

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [DeepDive](http://deepdive.stanford.edu) - Creates structured information from unstructured data and integrates it into an existing database.
 * [Deeplearning4j](http://deeplearning4j.org/) - Distributed and multi-threaded deep learning library.
 * [H2O](http://0xdata.com/) - Analytics engine for statistics over big data.
+* [JSAT](https://github.com/EdwardRaff/JSAT) -  Numerous Machine Learning algorithms for pre-processing, classification, regression, and clustering. Some algorithms suport mult-threaded execution. 
 * [Weka](http://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization.
 
 ## Messaging


### PR DESCRIPTION
Bias note, I'm the author of JSAT. 

I was just emailed about adding JSAT (a general purpose Machine Learning library) to this list, so I went ahead and created a pull request. Regarding the contribution guidelines, I think (c) and (d) would  apply for JSAT. There simply are not many options for Machine Learning in Java, and most of them are meant for large distributed systems. JSAT is meant for single machine / in memory use, and has no dependencies. Compared to Weka, JSAT is [faster](http://jsatml.blogspot.com/2015/03/jsat-vs-weka-on-mnist.html) while having significantly less code and providing many more algorithms/options. Many of the algorithms implemented in JSAT are either the only publicly available implementation, or the only public implementation in Java. In some cases JSAT contains the only independently implemented version of the algorithm. 