### PR TITLE
Removed Java Code Geeks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Android Arsenal](https://android-arsenal.com)
 * [Google Java Style](http://google-styleguide.googlecode.com/svn/trunk/javaguide.html)
 * [InfoQ](http://www.infoq.com/)
-* [Java Code Geeks](http://www.javacodegeeks.com/)
 * [Java, SQL, and jOOQ](http://blog.jooq.org/)
 * [Java.net](https://home.java.net/)
 * [Javalobby](https://dzone.com/java-jdk-development-tutorials-tools-news)


### PR DESCRIPTION
The site doesn't provide more information, instead it is bloated with advertisement and modals.