### PR TITLE
Added tinylog as logging framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [logstash](https://www.elastic.co/products/logstash) - Tool for managing log files.
 * [Metrics](https://github.com/dropwizard/metrics) - Expose metrics via JMX or HTTP and can send them to a database.
 * [SLF4J](http://www.slf4j.org/) - Abstraction layer which is to be used with an implementation.
+* [tinylog](http://www.tinylog.org/) - Lightweight logging framework with static logger class.
 
 ## Machine Learning
 


### PR DESCRIPTION
tinylog is a lightweight logging framework for Java. In opposite to other frameworks, the logger of tinylog is static. Thereby the creating of an instance of the logger for each class is not necessary. tinylog can be configured by a fluent API as well as by properties files and log entries can be written to the console, in files or databases.