### PR TITLE
Adding Almanac converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Libraries related to handling date and time.*
 
+* [Almanac Converter](https://github.com/hypotemoose/almanac-converter) - Simple conversion between different calendar systems.
 * [Joda-Time](http://www.joda.org/joda-time/) - De facto standard date/time-library before Java 8.
 * [ThreeTenBP](https://github.com/ThreeTen/threetenbp) - Port of JSR 310 (java.time package) by the author of Joda-Time.
 * [Time4J](https://github.com/MenoData/Time4J) - Advanced date and time library.


### PR DESCRIPTION
The almanac-converter library provides conversion between different calendar systems: these include calendars that are both in use (Gregorian, Julian, Islamic) and defunct historical calendars (Maya, French Republican). It's also currently under active development and is still expanding. It is also compatible with the native Java Calendar as well as Joda-Time.