### PR TITLE
Adding commercial reference to commercial tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Tools that provide metrics and quality measurements.*
 
-* [Codacy](https://www.codacy.com) - Continuous static analysis, code coverage, and software metrics to automate code reviews.
 * [Checkstyle](https://github.com/checkstyle/checkstyle) - Static analysis of coding conventions and standards.
+* [Codacy](https://www.codacy.com) - Commercial (free for open source) continuous static analysis, code coverage, and software metrics to automate code reviews.
 * [Error Prone](https://github.com/google/error-prone) - Catches common programming mistakes as compile-time errors.
 * [FindBugs](http://findbugs.sourceforge.net/) - Static analysis of bytecode to find potential bugs.
 * [jQAssistant](http://jqassistant.org/) - Static code analysis with Neo4J-based query language.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Tools that provide metrics and quality measurements.*
 
 * [Checkstyle](https://github.com/checkstyle/checkstyle) - Static analysis of coding conventions and standards.
+* [Checker Framework](https://github.com/checkstyle/checkstyle) - Static analysis by enhanceing Java’s type system.
 * [Codacy](https://www.codacy.com) - Commercial (free for open source) continuous static analysis, code coverage, and software metrics to automate code reviews.
 * [Error Prone](https://github.com/google/error-prone) - Catches common programming mistakes as compile-time errors.
 * [FindBugs](http://findbugs.sourceforge.net/) - Static analysis of bytecode to find potential bugs.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Tools that provide metrics and quality measurements.*
 
 * [Checkstyle](https://github.com/checkstyle/checkstyle) - Static analysis of coding conventions and standards.
-* [Checker Framework](https://github.com/checkstyle/checkstyle) - Static analysis by enhanceing Java’s type system.
+* [Checker Framework](http://types.cs.washington.edu/checker-framework/) - Static analysis by enhanceing Java’s type system.
 * [Codacy](https://www.codacy.com) - Commercial (free for open source) continuous static analysis, code coverage, and software metrics to automate code reviews.
 * [Error Prone](https://github.com/google/error-prone) - Catches common programming mistakes as compile-time errors.
 * [FindBugs](http://findbugs.sourceforge.net/) - Static analysis of bytecode to find potential bugs.


### PR DESCRIPTION
Fixes two issues:
- The alphabetical ordering within a section should be preserved
- Properly identifies the tool as a commercial (free for open source) tool