### PR TITLE
Adds networking library urnlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Nifty](https://github.com/facebook/nifty) - Implementation of Thrift clients and servers on Netty.
 * [OkHttp](http://square.github.io/okhttp/) - HTTP+SPDY client.
 * [Undertow](http://undertow.io/) - Web server providing both blocking and non-blocking API’s based on NIO. Used as a network layer in WildFly.
+* [urnlib](https://github.com/slub/urnlib) - Java library for representing, parsing and encoding URNs as in RFC 2141.
 
 ## ORM
 


### PR DESCRIPTION
This library implements the a class for representing an Uniform Resource Name (URN). It implements parsing and serialization according to the constraints defined in [RFC 2141](https://tools.ietf.org/html/rfc2141). It's released on [Maven Central](http://search.maven.org/#artifactdetails|de.slub-dresden|urnlib|1.0.0|jar) and aims to serve as a network identifier handling library just like the native Java URL and URI classes.

I'm not entirely sure `Networking` is the proper category, but I also don't see any other category it might fit.