### PR TITLE
The junit-dataprovider - a TestNG like dataprovider runner for JUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JGiven](http://jgiven.org) - Developer-friendly BDD testing framework compatible with JUnit and TestNG.
 * [JMockit](http://jmockit.org/) - Mocks static, final methods and more.
 * [JUnit](http://junit.org/) - Common testing framework.
+* [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - Creation of readable and maintainable parametrised tests.
 * [JUnitParams](https://pragmatists.github.io/JUnitParams/) - Creation of readable and maintainable parametrised tests.
 * [Mockito](https://github.com/mockito/mockito) - Creation of test double objects in automated unit tests for the purpose of TDD or BDD.
 * [Moco](https://github.com/dreamhead/moco) - Concise web services for stubs and mocks, Duke's Choice Award 2013.

--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JGiven](http://jgiven.org) - Developer-friendly BDD testing framework compatible with JUnit and TestNG.
 * [JMockit](http://jmockit.org/) - Mocks static, final methods and more.
 * [JUnit](http://junit.org/) - Common testing framework.
-* [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - Creation of readable and maintainable parametrised tests.
+* [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - A TestNG like dataprovider runner for JUnit.
 * [JUnitParams](https://pragmatists.github.io/JUnitParams/) - Creation of readable and maintainable parametrised tests.
 * [Mockito](https://github.com/mockito/mockito) - Creation of test double objects in automated unit tests for the purpose of TDD or BDD.
 * [Moco](https://github.com/dreamhead/moco) - Concise web services for stubs and mocks, Duke's Choice Award 2013.


### PR DESCRIPTION
JUnitParams is on list but I couldn't use it by maven-surefire-plugin in parallel execution mode. It just doesn't work. The junit-dataprovider is alternative which is awesome too and I think it's worth to add it to the list.