### PR TITLE
Orbit URL has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Hystrix](https://github.com/Netflix/Hystrix) - Provides latency and fault tolerance.
 * [JGroups](http://www.jgroups.org/) - Toolkit for reliable messaging and creating clusters.
 * [Lagom](https://www.lightbend.com/lagom) - Framework for creating microservice-based systems.
-* [Orbit](http://orbit.bioware.com/) - Virtual Actors, adding another level of abstraction to traditional actors.
+* [Orbit](http://www.orbit.cloud/) - Virtual Actors, adding another level of abstraction to traditional actors.
 * [Pinpoint](https://github.com/naver/pinpoint) - Application performance management tool.
 * [Quasar](http://www.paralleluniverse.co/quasar/) - Lightweight threads and actors for the JVM.
 


### PR DESCRIPTION
Hi, 
I'm the maintainer of the orbit framework and we recently changed primary URLs so submitting this update.

I was also wondering if it's possible to update the source code link at https://java.libhunt.com/project/orbit. 
I realise you don't own this so tagging @StanBright to see how that works. 
It should be https://github.com/orbit/orbit. So the site accurately reflects activity etc.

Thanks!
Joe