### PR TITLE
Add TypeTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [LightAdmin](http://lightadmin.org/) - Pluggable CRUD UI library for rapid application development.
 * [Modern Java - A Guide to Java 8](https://github.com/winterbe/java8-tutorial) - Popular Java 8 guide.
 * [OpenRefine](http://openrefine.org/) - Tool for working with messy data: cleaning, transforming, extending it with web services and linking it to databases.
+* [TypeTools](https://github.com/jhalterman/typetools) - Tools for resolving generic types.
 
 ## Monitoring
 


### PR DESCRIPTION
[TypeTools](https://github.com/jhalterman/typetools) is a simply library for resolving generic type information. It's fairly unique, though one similar library, [ClassMate](https://github.com/FasterXML/java-classmate), also exists. They differ in a few ways, one of which includes TypeTools' support for resolving generic type information from lambda expressions and method references. It is currently used in various companies/projects.