### PR TITLE
Move cglib to Bytecode Manipulation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Apache Hadoop](http://hadoop.apache.org/) - Storage and large-scale processing of data-sets on clusters of commodity hardware.
 * [Apache OpenNLP](https://opennlp.apache.org/) - Toolkit for common tasks like tokenization.
 * [Apache Velocity](http://velocity.apache.org/) - Templates for HTML pages, emails or source code generation in general.
-* [cglib](https://github.com/cglib/cglib) - Bytecode generation library.
 * [FreeMarker](http://freemarker.org/) - General templating engine without any heavyweight or opinionated dependencies.
 * [GlassFish](https://glassfish.java.net/) - Application server and reference implementation for Java EE sponsored by Oracle.
 * [GWT](http://www.gwtproject.org/) - Toolbox which includes a Java-to-JavaScript compiler for client-side code, XML parser, API for RPC, JUnit integration, internationalization support and widgets for the GUI.
@@ -117,6 +116,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [ASM](http://asm.ow2.org/) - All purpose, low level, bytecode manipulation and analysis.
 * [Byte Buddy](http://bytebuddy.net/) - Further simplifies bytecode generation with a fluent API.
 * [Byteman](http://byteman.jboss.org/) - Manipulate bytecode at runtime via DSL (rules) mainly for testing/troubleshooting.
+* [cglib](https://github.com/cglib/cglib) - Bytecode generation library.
 * [Javassist](http://jboss-javassist.github.io/javassist/) - Tries to simplify the editing of bytecode.
 
 ## Cluster Management


### PR DESCRIPTION
This PR is pretty subjective so feel free to consider it as such, but I think cglib fits better with the rest of the bytecode manipulation libraries since it is similar to some of them and helped inspire the creation of others.

I can understand why this is considered an ancient since it might not be the library you choose to adopt today, but there are still good reasons for adopting it (much smaller dependency than ByteBuddy) and it's still widely used in numerous important technologies including Spring Framework.