### PR TITLE
Add "Cukes-REST" - a collection of steps for Cucumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Awaitility](https://github.com/jayway/awaitility) - DSL for synchronizing asynchronous operations.
 * [Citrus](http://citrusframework.org/) - Integration testing framework with focus on client- and serverside messaging.
 * [Cucumber](https://github.com/cucumber/cucumber-jvm) - BDD testing framework.
+* [Cukes-REST](https://github.com/ctco/cukes-rest) - A collection of Gherkin steps for REST-service testing using Cucumber.
 * [Gatling](http://gatling.io/) - Load testing tool designed for ease of use, maintainability and high performance.
 * [GreenMail](http://www.icegreen.com/greenmail/) - In-memory email server for integration testing. Supports SMTP, POP3 and IMAP including SSL.
 * [Hamcrest](http://hamcrest.org/JavaHamcrest/) - Matchers that can be combined to create flexible expressions of intent.


### PR DESCRIPTION
Dear team,

I propose adding a "**Cukes-REST**" library, which contains a collection of essential Gherkin steps to do REST-service testing. It contains everything that tester needs in order to do this testing of REST using **Cucumber** framewotk.

Please take a look :)

Thanks,
Igor