### PR TITLE
Create a new Caching section, and add Caffeine & move Ehcache to it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated list of awesome Java frameworks, libraries and software.
     - [Bean Mapping](#bean-mapping)
     - [Build](#build)
     - [Bytecode Manipulation](#bytecode-manipulation)
+    - [Caching](#caching)
     - [Cluster Management](#cluster-management)
     - [Code Analysis](#code-analysis)
     - [Code Coverage](#code-coverage)
@@ -120,6 +121,13 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Byteman](http://byteman.jboss.org/) - Manipulate bytecode at runtime via DSL (rules) mainly for testing/troubleshooting.
 * [cglib](https://github.com/cglib/cglib) - Bytecode generation library.
 * [Javassist](http://jboss-javassist.github.io/javassist/) - Tries to simplify the editing of bytecode.
+
+## Caching
+
+*Libraries which provide caching facilities.*
+
+* [Caffeine](https://github.com/ben-manes/caffeine) - High performance, near optimal caching library.
+* [Ehcache](http://www.ehcache.org/) - Distributed general purpose cache.
 
 ## Cluster Management
 
@@ -276,7 +284,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Atomix](http://atomix.io/atomix/) - Fault-tolerant distributed coordination framework.
 * [Axon Framework](http://www.axonframework.org/) - Framework for creating CQRS applications.
 * [Copycat](http://atomix.io/copycat/) - Fault-tolerant state machine replication framework.
-* [Ehcache](http://www.ehcache.org/) - Distributed general purpose cache.
 * [Hazelcast](http://hazelcast.org/) - Highly scalable in-memory datagrid.
 * [Hystrix](https://github.com/Netflix/Hystrix) - Provides latency and fault tolerance.
 * [JGroups](http://www.jgroups.org/) - Toolkit for reliable messaging and creating clusters.


### PR DESCRIPTION
According to their [GitHub page](https://github.com/ben-manes/caffeine), Caffeine is a highly performant caching library for Java 8 which takes lessons from [Guava's Cache](https://github.com/google/guava/wiki/CachesExplained) and [ConcurrentLinkedHashMap](https://code.google.com/p/concurrentlinkedhashmap). It's so fine-tuned performance-wise that there are early discussions going on to replace caches in [HBase](https://issues.apache.org/jira/browse/HBASE-15560), [Cassandra](https://issues.apache.org/jira/browse/CASSANDRA-10855), [Solr](https://issues.apache.org/jira/browse/SOLR-8241) and [ElasticSearch](https://github.com/elastic/elasticsearch/issues/16802) with Caffeine. Therefore I believe it's worth adding to the list.

Since none of the existing sections seem to match well with Caffeine, I decided to add a new Caching section and move Ehcache to this new section as well.