### PR TITLE
Added Jackson-datatype-money under "JSON"

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Genson](http://owlike.github.io/genson/) - Powerful and easy to use Java to JSON conversion library.
 * [Gson](https://github.com/google/gson) - Serializes objects to JSON and vice versa. Good performance with on-the-fly usage.
 * [Jackson](http://wiki.fasterxml.com/JacksonHome) - Similar to GSON but has performance gains if you need to instantiate the library more often.
+* [Jackson-datatype-money](https://github.com/zalando/jackson-datatype-money) - Open-source Jackson module to support JSON serialization and deserialization of JavaMoney data types.
 * [JSON-io](https://github.com/jdereg/json-io) - Convert Java to JSON. Convert JSON to Java. Pretty print JSON. Java JSON serializer.
 * [LoganSquare](https://github.com/bluelinelabs/LoganSquare) - JSON parsing and serializing library based on Jackson's streaming API. Outperforms GSON & Jackson's library.
 


### PR DESCRIPTION
It's a Jackson module that enables you to express monetary amounts in JSON, can be used in a REST APIs, offers customizable serialization by locale, and allows you to implement RESTful API endpoints that format monetary amounts based on the Accept-Language header.