### PR TITLE
really-executable-jars-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JitPack](https://jitpack.io/) - Easy to use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.
 * [Nexus](http://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.
 * [packr](https://github.com/libgdx/packr/) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and Mac OS X.
-* [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - maven plugin for making chmod +x jar files. Packages a ([standalone executable JAR](https://maven.apache.org/plugins/maven-shade-plugin/examples/executable-jar.html)) as a file that can be run on its own, without having to prefix it with `java -jar` explicitly. Detailed explanation in <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>.
+* [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - Maven plugin for making [self-executing `chmod +x` jar files](http://skife.org/java/unix/2011/06/20/really_executable_jars.html).
 
 ## Document Processing
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JitPack](https://jitpack.io/) - Easy to use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.
 * [Nexus](http://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.
 * [packr](https://github.com/libgdx/packr/) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and Mac OS X.
-* [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - 
+* [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - maven plugin for making chmod +x jar files. Packages a ([standalone executable JAR](https://maven.apache.org/plugins/maven-shade-plugin/examples/executable-jar.html)) as a file that can be run on its own, without having to prefix it with `java -jar` explicitly. Detailed explanation in <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>.
 
 ## Document Processing
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JitPack](https://jitpack.io/) - Easy to use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.
 * [Nexus](http://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.
 * [packr](https://github.com/libgdx/packr/) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and Mac OS X.
+* [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - 
 
 ## Document Processing
 


### PR DESCRIPTION
Packages a shaded jar into an executable that can be executed directly (like any other executable file, without having to invoke java explicitly). 
Details at http://skife.org/java/unix/2011/06/20/really_executable_jars.html

This project is:

>
(c) absolutely unique in its approach and function
(d) a niche product that fills a gap