### PR TITLE
Update README.md to add baratine.io framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 * [Apache Tapestry](http://tapestry.apache.org/) - Component-oriented framework for creating dynamic, robust, highly scalable web applications.
 * [Apache Wicket](http://wicket.apache.org/) - Component-based web application framework similar to Tapestry with a stateful GUI.
+* [Baratine](http://baratine.io) - Asynchronous Java framework with unified single-thread & data model for standalone or embedded(.jar) high performing REST & WebSocket Microservices.
 * [Blade](https://github.com/biezhi/blade) - Lightweight, modular framework which aims to be elegant and simple.
 * [Grails](https://grails.org/) - Groovy framework with the aim to provide a highly productive environment by favoring convention over configuration, no XML and support for mixins.
 * [Jooby](http://jooby.org) - Scalable, fast and modular micro framework which offers multiple programming models.

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 * [Apache Tapestry](http://tapestry.apache.org/) - Component-oriented framework for creating dynamic, robust, highly scalable web applications.
 * [Apache Wicket](http://wicket.apache.org/) - Component-based web application framework similar to Tapestry with a stateful GUI.
-* [Baratine](http://baratine.io) - Asynchronous Java framework with unified single-thread & data model for standalone or embedded(.jar) high performing REST & WebSocket Microservices.
+* [Baratine](http://baratine.io) - Toolkit for building distributed and reactive applications for multiple environments, either standalone or embedded.
 * [Blade](https://github.com/biezhi/blade) - Lightweight, modular framework which aims to be elegant and simple.
 * [Grails](https://grails.org/) - Groovy framework with the aim to provide a highly productive environment by favoring convention over configuration, no XML and support for mixins.
 * [Jooby](http://jooby.org) - Scalable, fast and modular micro framework which offers multiple programming models.


### PR DESCRIPTION
Baratine functions as an operational (for business logic), datastore, & routing framework for creating microservices. Services in Java, clients in any language. It has reworked the thread & data programming model to provide asynchronous POJO microservices that do not have concurrency access or database bottleneck issues.