### PR TITLE
Takipi to OverOps Rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [New Relic](http://newrelic.com/) - Commercial performance monitor.
 * [Prometheus](https://prometheus.io/) - Provides a multi-dimensional data model, DSL, autonomous server nodes and much more.
 * [SPM](https://sematext.com/spm/) - Commercial performance monitor with distributing transaction tracing for JVM apps.
-* [Takipi](https://www.takipi.com/) - Commercial in-production error monitoring and debugging.
+* [OverOps](https://www.overops.com/) - Commercial in-production error monitoring and debugging.
 * [Stagemonitor](https://github.com/stagemonitor/stagemonitor) - Open source performance monitoring and transaction tracing for JVM apps.
 * [Glowroot](https://glowroot.org/) - Open source Java APM.
 * [Pinpoint](https://github.com/naver/pinpoint) - Open source APM tool.


### PR DESCRIPTION
Changing Takipi to OverOps due to rebranding. Takipi blog stays the same