### PR TITLE
Added JITWatch to Performance analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [GCeasy ![c]](http://gceasy.io) - Tool to analyze and visualize GC logs. It provides a free cloud-based upload interface.
 * [honest-profiler](https://github.com/RichardWarburton/honest-profiler) - An low-overhead, bias-free sampling profiler.
 * [jHiccup](https://github.com/giltene/jHiccup) - Logs and records platform JVM stalls.
+* [JITWatch](https://github.com/AdoptOpenJDK/jitwatch) - Analyze the JIT compiler optimisations made by the HotSpot JVM.
 * [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - JMH is a Java harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM.
 * [JProfiler ![c]](https://www.ej-technologies.com/products/jprofiler/overview.html) - Profiler.
 * [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.


### PR DESCRIPTION
Hi, please would you consider adding JITWatch to the performance analysis section?

JITWatch analyses the Just-In-Time compilation logs output by the HotSpot JVM (using the -XX:LogCompilation flag). It highlights method inlining, escape analysis, intrinsic use, lock elision, etc.

Results are visualised by linking and annotating the corresponding source, bytecode, and disassembled native code. It also produces reports, graphs, and histograms on HotSpot JIT activity.

Thank you.

NB I'm the author of JITWatch.