### PR TITLE
request to add Erdos

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [GraphStream](http://graphstream-project.org/) - Library for modeling and analysis of dynamic graphs.
 * [JGraphT](https://github.com/jgrapht/jgrapht) - Graph library that provides mathematical graph-theory objects and algorithms.
 * [JGraphX](https://github.com/jgraph/jgraphx) - Library for visualisation (mainly Swing) and interaction with node-edge graphs.
+* [Erdos](https://github.com/Erdos-Graph-Framework/Erdos) - Modular, light and easy graph theoretic framework.
 
 ## Search
 


### PR DESCRIPTION
Hi, will you please consider [**Erdos**](https://github.com/Erdos-Graph-Framework/Erdos) ?

[**Erdos**](https://github.com/Erdos-Graph-Framework/Erdos) is a very light, modular and super easy to use modern Graph theoretic algorithms framework for Java. It contains graph algorithms that you can apply swiftly with **one line of code** and was primarily developed to back a worker manager tasks for various Java projects including one in Android. 

Erdos was written because other frameworks in Java were very hard to get started with or just plain heavy (overhead wise) or just too opinionated. Erdos let the developer design it's own graph engines to optimise the runtime and comes with all of the graph algorithms you can expect.

all the best