### PR TITLE
Add Polyglot for Maven to Everything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Modern Java - A Guide to Java 8](https://github.com/winterbe/java8-tutorial) - Popular Java 8 guide.
 * [Modernizer](https://github.com/andrewgaul/modernizer-maven-plugin) - Detect uses of legacy Java APIs.
 * [OpenRefine](http://openrefine.org/) - Tool for working with messy data: cleaning, transforming, extending it with web services and linking it to databases.
+* [Polyglot for Maven](https://github.com/takari/polyglot-maven/) - Set of extensions for Maven 3.3.1+ that allows the POM model to be written in dialects other than XML.
 * [TypeTools](https://github.com/jhalterman/typetools) - Tools for resolving generic types.
 
 ## Microservice


### PR DESCRIPTION
Adds native support for YAML, groovy, atom… POMs which improves readability.
it’s currently supported by IDEA and it’s used in several real life projects.

#482 