### PR TITLE
Add schemaspy - java based database documentation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Querydsl](http://www.querydsl.com/) - Typesafe unified queries.
 * [Realm](https://github.com/realm/realm-java) - Mobile database to run directly inside phones, tablets or wearables.
 * [Redisson](https://github.com/mrniko/redisson) - Allows for distributed and scalable data structures on top of a Redis server.
+* [Schemaspy](http://schemaspy.org/) - Tool that analyzes the metadata of a schema in a database and generates a documentation, including entity relationship diagrams.
 * [Speedment](https://github.com/speedment/speedment) - Database access library that utilizes the Java 8 Stream API for querying.
 * [sql2o](http://sql2o.org/) - Thin JDBC wrapper that simplifies database access and provides simple mapping of ResultSets to POJOs.
 * [Vibur DBCP](http://www.vibur.org/) - JDBC connection pool library which offers advanced performance monitoring capabilities.


### PR DESCRIPTION
SchemaSpy is a Java-based tool (requires Java 8 or higher) that analyzes the metadata of a schema in a database and generates a visual representation of it in a browser-displayable format. It lets you click through the hierarchy of database tables via child and parent table relationships as represented by both HTML links and entity-relationship diagrams. It’s also designed to help resolve the obtuse errors that a database sometimes gives related to failures due to constraints. It is free software that is distributed under the terms of the MIT License.
http://schemaspy.org/