### PR TITLE
Add ArchUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Tools that test from model to the view.*
 
 * [Apache JMeter](http://jmeter.apache.org/) - Functional testing and performance measurements.
+* [ArchUnit](https://github.com/TNG/ArchUnit) - Architecture test library, to specify and assert architecture rules in plain Java.
 * [Arquillian](http://arquillian.org/) - Integration and functional testing platform for Java EE containers.
 * [AssertJ](http://joel-costigliola.github.io/assertj/) - Fluent assertions that improve readability.
 * [Awaitility](https://github.com/jayway/awaitility) - DSL for synchronizing asynchronous operations.

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Tools that test from model to the view.*
 
 * [Apache JMeter](http://jmeter.apache.org/) - Functional testing and performance measurements.
-* [ArchUnit](https://github.com/TNG/ArchUnit) - Architecture test library, to specify and assert architecture rules in plain Java.
+* [ArchUnit](https://github.com/TNG/ArchUnit) - Architecture test library, to specify and assert architecture rules.
 * [Arquillian](http://arquillian.org/) - Integration and functional testing platform for Java EE containers.
 * [AssertJ](http://joel-costigliola.github.io/assertj/) - Fluent assertions that improve readability.
 * [Awaitility](https://github.com/jayway/awaitility) - DSL for synchronizing asynchronous operations.


### PR DESCRIPTION
[ArchUnit](https://github.com/TNG/ArchUnit) is unique in its approach. It provides a method to add unit tests on the architecture of a system based on a fluent API.

The alternative is [Macker](https://innig.net/macker/index.html), which also implements architecture checks. Example: https://innig.net/macker/example/layering/src/macker.xml. However, it is very outdated and thus not awesome.