### PR TITLE
Remove SnopEE

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Eureka](https://github.com/Netflix/eureka) - REST based service registry for resilient load balancing and failover.
 * [Lagom](https://www.lightbend.com/lagom) - Framework for creating microservice-based systems.
 * [restQL-core](https://github.com/B2W-BIT/restQL-core) - Microservice query language that fetches information from multiple services.
-* [SnopEE](https://github.com/ivargrimstad/snoop) - Discovery service for Java EE microservices.
 
 ## Monitoring
 


### PR DESCRIPTION
I think this is a bit immature to be awesome, the library is self-confessed experimental The development also seems to have split into 2 repos: https://github.com/ivargrimstad/snoop and https://github.com/ivargrimstad/snoop**ee**