### PR TITLE
Added MinimalFTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Apache Tomcat](http://tomcat.apache.org/) - Robust all-round server for Servlet and JSP.
 * [Apache TomEE](http://tomee.apache.org/) - Tomcat plus Java EE.
 * [Jetty](http://www.eclipse.org/jetty/) - Lightweight, small server, often embedded in projects.
+* [MinimalFTP](https://github.com/Guichaguri/MinimalFTP) - Lightweight, small and customizable FTP server.
 * [nanohttpd](https://github.com/NanoHttpd/nanohttpd) - Tiny, easily embeddable HTTP server.
 * [WebSphere Liberty](https://developer.ibm.com/wasdev/) - Lightweight, modular server developed by IBM.
 * [WildFly](http://www.wildfly.org/) - Formerly known as JBoss and developed by Red Hat with extensive Java EE support.


### PR DESCRIPTION
MinimalFTP is a lightweight, simple FTP server written in Java. It is licensed under GPL 3.0, but I'll probably be re-licensing it under Apache 2.0
It supports 58 FTP commands, TLS/SSL, custom file system, custom user authentication, custom commands, etc.