### PR TITLE
Add Unirest Java to HTTP Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Retrofit](http://square.github.io/retrofit/) - Typesafe REST client.
 * [Ribbon](https://github.com/Netflix/ribbon) - Client-side IPC library that is battle-tested in cloud.
 * [Riptide](https://github.com/zalando/riptide) - Client-side response routing for Spring's RestTemplate.
+* [Unirest Java](https://github.com/Mashape/unirest-java) - Simplified, lightweight HTTP client library.
 
 ## Hypermedia Types
 


### PR DESCRIPTION
Please consider adding [Unirest Java](http://unirest.io/java.html) to HTTP Clients. It is a great package and well maintained.