### PR TITLE
Move RxJava to Ancients again

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [JUnit](http://junit.org/) - Common testing framework.
 * [Launch4j](http://launch4j.sourceforge.net/) - Wraps JARs in lightweight and native Windows executables.
 * [Quartz](https://github.com/quartz-scheduler/quartz) - Open-source job scheduler library with Apache 2.0 license.
+* [RxJava](https://github.com/ReactiveX/RxJava) - Library for composing asynchronous and event-based programs using observable sequences from the JVM.
 * [TestNG](http://testng.org/) - Testing framework inspired by JUnit and NUnit, with different functionalities.
 * [Trove](http://trove.starlight-systems.com/) - High-performance primitive collections.
 
@@ -687,7 +688,6 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Akka](http://akka.io) - Toolkit and runtime for building concurrent, distributed, fault-tolerant and event-driven applications.
 * [Reactive Streams](https://github.com/reactive-streams/reactive-streams-jvm/) - Provides a standard for asynchronous stream processing with non-blocking backpressure.
 * [Reactor](http://projectreactor.io/) - Library for building reactive fast-data applications.
-* [RxJava](https://github.com/ReactiveX/RxJava) - Library for composing asynchronous and event-based programs using observable sequences from the JVM.
 * [vert.x](http://vertx.io/) - Polyglot event-driven application framework.
 
 ## REST Frameworks


### PR DESCRIPTION
@akullpp I'm a bit confused :). I see that you merged the request and, at the same time, I see your comment and [Change Spring URL to projects](https://github.com/akullpp/awesome-java/commit/5c05e03ba2f504d537c8e5b23d875eeaa7c2902b) commit that effectively reverts it. Is it an accidental change?

PS anyway, I understand your concern. RxJava has a solid ecosystem but at the same time, it's hard to keep it on the list because even the author says to use a different technology if you can.  It seems like an exact match to Ancients section (a good technology but you should not start new projects with it).
Additionally, it can be really confusing to people who are using the list because RxJava has more starts, more mentions,  dedicated awesome list and, at the same time, the author's tweet by far is not the first link in the google search result for "RxJava vs reactor". 

What do you think ?