### PR TITLE
Add dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [centraldogma](https://github.com/line/centraldogma) - Highly-available version-controlled service configuration repository based on Git, ZooKeeper and HTTP/2.
 * [cfg4j](https://github.com/cfg4j/cfg4j) - Modern configuration library for distributed apps written in Java.
 * [config](https://github.com/typesafehub/config) - Configuration library for JVM languages.
+* [dotenv](https://github.com/shyiko/dotenv) - A twelve-factor configuration library for Java.
 * [ini4j](http://ini4j.sourceforge.net/) - Provides an API for handling Windows' INI files.
 * [KAConf](https://github.com/mariomac/kaconf) - Annotation-based configuration system for Java and Kotlin.
 * [owner](https://github.com/lviggiano/owner) - Reduces boilerplate of properties.


### PR DESCRIPTION
A [twelve-factor configuration](https://12factor.net/config) library for Java 8+  
([bkeepers/dotenv](https://github.com/bkeepers/dotenv) (Ruby), [motdotla/dotenv](https://github.com/motdotla/dotenv) (Node.js), [joho/godotenv](https://github.com/joho/godotenv) (Go), etc. equivalent for JVM). 