### PR TITLE
Suggest ScaleCube.io cluster-membership protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [Orbit](http://www.orbit.cloud/) - Virtual actors; adds another level of abstraction to traditional actors.
 * [Quasar](https://www.paralleluniverse.co/quasar/) - Lightweight threads and actors for the JVM.
 * [resilience4j](https://github.com/resilience4j/resilience4j) - Functional fault tolerance library.
+* [ScaleCube](https://github.com/scalecube/scalecube) - Embeddable Cluster-Membership library based on SWIM and gossip protocol.
 * [Zuul](https://github.com/Netflix/zuul) - A gateway service that provides dynamic routing, monitoring, resiliency, security, and more.
 
 ## Distributed Transactions


### PR DESCRIPTION
[ScaleCube.io](http://scalecube.io) is modular Embeddable  set of libraries:

scalecube-cluster is a Cluster-Membership library based on [SWIM](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf) and gossip protocol. that can be used for any cluster-aware distributed applications and architecture such as microservices 

To add a dependency on ScaleCube Cluster using Maven, use the following:

``` xml
<dependency>
  <groupId>io.scalecube</groupId>
  <artifactId>scalecube-cluster</artifactId>
  <version>x.y.z</version>
</dependency>
```