### PR TITLE
Add MinimalFTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ A curated list of awesome Java frameworks, libraries and software.
 * [LightAdmin](http://lightadmin.org/) - Pluggable CRUD UI library for rapid application development.
 * [Maven Wrapper](https://github.com/takari/maven-wrapper) - Analogue of Gradle Wrapper for Maven, allows building projects without installing maven.
 * [Membrane Service Proxy](https://github.com/membrane/service-proxy) - An open-source, reverse-proxy framework written in Java.
+* [MinimalFTP](https://github.com/Guichaguri/MinimalFTP) - Lightweight, small and customizable FTP server.
 * [Modern Java - A Guide to Java 8](https://github.com/winterbe/java8-tutorial) - Popular Java 8 guide.
 * [Modernizer](https://github.com/andrewgaul/modernizer-maven-plugin) - Detect uses of legacy Java APIs.
 * [Multi-OS Engine](https://software.intel.com/en-us/multi-os-engine) - An open-source, cross-platform engine to develop native mobile (iOS, Android, etc.) apps.


### PR DESCRIPTION
This PR adds MinimalFTP, a lightweight, simple FTP server written in Java, licensed under Apache 2.0.

It supports 55 FTP commands (14 RFCs), TLS/SSL, custom file system, custom user authentication, custom commands and also supports a few obsolete commands (older FTP clients might still use them).