### PR TITLE
add jasync-sql -  Java async database driver for MySQL and PostgreSQL written in Kotlin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Flyway](https://flywaydb.org) - Simple database migration tool.
 - [H2](https://h2database.com) - Small SQL database notable for its in-memory functionality.
 - [HikariCP](https://github.com/brettwooldridge/HikariCP) - High-performance JDBC connection pool.
+- [jasync-sql](https://github.com/jasync-sql/jasync-sql) - Async DB driver for MySQL and PostgreSQL.
 - [JDBI](http://jdbi.org) - Convenient abstraction of JDBC.
 - [Jedis](https://github.com/xetorthio/jedis) - Small client for interaction with Redis, with methods for commands.
 - [Jest](https://github.com/searchbox-io/Jest) - Client for the Elasticsearch REST API.


### PR DESCRIPTION
https://github.com/jasync-sql/jasync-sql
It is fairly new, but haven't seen other such drivers except for its deprecated predecessor: https://github.com/mauricio/postgresql-async