### PR TITLE
Add TLS Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Netty](https://netty.io) - Framework for building high-performance network applications.
 - [Nifty](https://github.com/facebook/nifty) - Implementation of Thrift clients and servers on Netty.
 - [sshj](https://github.com/hierynomus/sshj) - Programatically use SSH, SCP or SFTP.
+- [TLS Channel](https://github.com/marianobarrios/tls-channel) - A library that implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly.
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141.
 

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Netty](https://netty.io) - Framework for building high-performance network applications.
 - [Nifty](https://github.com/facebook/nifty) - Implementation of Thrift clients and servers on Netty.
 - [sshj](https://github.com/hierynomus/sshj) - Programatically use SSH, SCP or SFTP.
-- [TLS Channel](https://github.com/marianobarrios/tls-channel) - A library that implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
+- [TLS Channel](https://github.com/marianobarrios/tls-channel) - Implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly.
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141.
 


### PR DESCRIPTION
This PR adds TLS Channel, an open source (MIT) library that implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.

I am the main author of the library, but I still request consideration, based on the fact that the project has a very specific purpose, which is both important (actually, a surprising omision in the JDK) and is not covered by any existing (to my knowledge) library, at least in the form of a specific solution.

Thanks.