### PR TITLE
Added entry bucket4j - Java rate limiting library based on token-bucket algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Libraries which provide general utility functions.*
 
+- [bucket4j](https://github.com/vladimir-bukhtoyarov/bucket4j) - Java rate limiting library based on token-bucket algorithm. 
 - [cactoos](http://www.cactoos.org) - Collection of object-oriented primitives.
 - [CRaSH](http://www.crashub.org) - Provides a shell into a JVM that's running CRaSH. Used by Spring Boot and others.
 - [Dex](https://github.com/PatMartin/Dex) - Java/JavaFX tool capable of powerful ETL and data visualization.


### PR DESCRIPTION
Bucket4j - is Java rate-limiting library based on token-bucket algorithm.
The one can implement throttling mechanism as an example of usage.
Can be used in pair with distributed caches (IMDG) like Hazelcast, Apache Ignite etc.