### PR TITLE
Add Cloudsmith (a Maven-compatible service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Boxfuse](https://boxfuse.com) - Deployment of JVM applications to AWS using the principles of immutable infrastructure.
 - [Capsule](http://www.capsule.io) - Simple and powerful packaging and deployment. A fat JAR on steroids, or a "Docker for Java" that supports JVM-optimized containers.
 - [Central Repository](https://search.maven.org) - Largest binary component repository available as a free service to the open-source community. Default used by Apache Maven, and available in all other build tools.
-- [Cloudsmith ![c]](https://cloudsmith.io) - A fully managed package management SaaS with support for Maven/Gradle/SBT (and many others).
+- [Cloudsmith ![c]](https://cloudsmith.io) - Fully managed package management SaaS with support for Maven/Gradle/SBT.
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
 - [JitPack](https://jitpack.io) - Easy-to-use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.
 - [Nexus ![c]](https://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Boxfuse](https://boxfuse.com) - Deployment of JVM applications to AWS using the principles of immutable infrastructure.
 - [Capsule](http://www.capsule.io) - Simple and powerful packaging and deployment. A fat JAR on steroids, or a "Docker for Java" that supports JVM-optimized containers.
 - [Central Repository](https://search.maven.org) - Largest binary component repository available as a free service to the open-source community. Default used by Apache Maven, and available in all other build tools.
+- [Cloudsmith ![c]](https://cloudsmith.io) - A fully managed package management SaaS with support for Maven/Gradle/SBT (and many others).
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
 - [JitPack](https://jitpack.io) - Easy-to-use package repository for GitHub. Builds Maven/Gradle projects on demand and publishes ready-to-use packages.
 - [Nexus ![c]](https://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.


### PR DESCRIPTION
This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Maven-compatible repositories (and many other package formats, such as Python/Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc.

*Full disclosure:* I work at Cloudsmith.