### PR TITLE
PR to add code climate analysis platform link

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [NullAway](https://github.com/uber/NullAway) - Eliminates NullPointerExceptions with low build-time overhead.
 - [PMD](https://github.com/pmd/pmd) - Source code analysis for finding bad coding practices.
 - [SonarJava](https://github.com/SonarSource/sonar-java) - Static analyzer for SonarQube & SonarLint.
+- [Code Climate](https://github.com/codeclimate/codeclimate) - Is a command line interface for the Code Climate analysis platform.
 - [Sourcetrail ![c]](https://www.sourcetrail.com) - Visual source code navigator.
 - [Spoon](https://github.com/INRIA/spoon) - Library for analyzing and transforming Java source code.
 - [Spotbugs](https://github.com/spotbugs/spotbugs) - Static analysis of bytecode to find potential bugs.


### PR DESCRIPTION
This PR adds a link to Code Climate, which is a command line interface for the Code Climate analysis platform. In code on Github It allows you to run Code Climate engines on your local machine inside of Docker containers.