### PR TITLE
Add jbock

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Jansi](https://github.com/fusesource/jansi) - ANSI escape codes to format console output.
 - [Java ASCII Render](https://github.com/indvd00m/java-ascii-render) - Graphical primitives for the console.
 - [JCommander](http://jcommander.org) - Command-line argument-parsing framework with custom types and validation via implementing interfaces.
+- [jbock](https://github.com/h908714124/jbock) - Typesafe, reflection-free, annotation based command line parser 
 - [JLine](https://github.com/jline/jline3) - Includes features from modern shells like completion or history.
 - [JOpt Simple](https://pholser.github.io/jopt-simple) - Fluent parser that uses the POSIX#getopt and GNU#getopt_long syntaxes.
 - [picocli](http://picocli.info) - ANSI colors and styles in usage help with annotation-based POSIX/GNU/any syntax, subcommands, strong typing for both options and positional args.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Jansi](https://github.com/fusesource/jansi) - ANSI escape codes to format console output.
 - [Java ASCII Render](https://github.com/indvd00m/java-ascii-render) - Graphical primitives for the console.
 - [JCommander](http://jcommander.org) - Command-line argument-parsing framework with custom types and validation via implementing interfaces.
-- [jbock](https://github.com/h908714124/jbock) - Typesafe, reflection-free, annotation based command line parser 
+- [jbock](https://github.com/h908714124/jbock) - Typesafe, reflection-free, annotation based command-line parser 
 - [JLine](https://github.com/jline/jline3) - Includes features from modern shells like completion or history.
 - [JOpt Simple](https://pholser.github.io/jopt-simple) - Fluent parser that uses the POSIX#getopt and GNU#getopt_long syntaxes.
 - [picocli](http://picocli.info) - ANSI colors and styles in usage help with annotation-based POSIX/GNU/any syntax, subcommands, strong typing for both options and positional args.


### PR DESCRIPTION
After more than a year of development, I think jbock is becoming stable. It has many unique and innovative features:

* It has a familiar interface, similar to jcommander, yet it doesn't use reflection.
* It gives you detailed error messages at compile time.
* It enforces the use of the `Optional<?>` type for optional parameters. It will not be a source of implicit defaults or `null` values in your program.
* It is simple, yet very flexible via custom mapper (which can be used for validation too) and collectors.
* It doesn't add a new dependency to your project. Its annotations are compile-time only. Everything else is only needed on the compiler classpath.
* It generates usage text from javadoc. Alternatively a resource bundle can be used.

I hope that this parser will be an inspiration for the java community.