### PR TITLE
Added P6Spy

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Logback](https://logback.qos.ch) - Robust logging library with interesting configuration options via Groovy.
 - [Logbook](https://github.com/zalando/logbook) - Extensible, open-source library for HTTP request and response logging.
 - [Logstash](https://www.elastic.co/products/logstash) - Tool for managing log files.
+- [p6spy](https://github.com/p6spy/p6spy) - P6Spy is a framework that enables database data to be seamlessly intercepted and logged with no code changes to the application.It logs all JDBC transactions for any Java application.
 - [SLF4J](https://www.slf4j.org) - Abstraction layer/simple logging facade.
 - [tinylog](http://www.tinylog.org) - Lightweight logging framework with static logger class.
 - [Tracer](https://github.com/zalando/tracer) - Call tracing and log correlation in distributed systems.

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Logback](https://logback.qos.ch) - Robust logging library with interesting configuration options via Groovy.
 - [Logbook](https://github.com/zalando/logbook) - Extensible, open-source library for HTTP request and response logging.
 - [Logstash](https://www.elastic.co/products/logstash) - Tool for managing log files.
-- [p6spy](https://github.com/p6spy/p6spy) - Framework that enables all JDBC transactions to be logged.
+- [p6spy](https://github.com/p6spy/p6spy) - Enables logging for all JDBC transactions without changes to the code.
 - [SLF4J](https://www.slf4j.org) - Abstraction layer/simple logging facade.
 - [tinylog](http://www.tinylog.org) - Lightweight logging framework with static logger class.
 - [Tracer](https://github.com/zalando/tracer) - Call tracing and log correlation in distributed systems.

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Logback](https://logback.qos.ch) - Robust logging library with interesting configuration options via Groovy.
 - [Logbook](https://github.com/zalando/logbook) - Extensible, open-source library for HTTP request and response logging.
 - [Logstash](https://www.elastic.co/products/logstash) - Tool for managing log files.
-- [p6spy](https://github.com/p6spy/p6spy) - P6Spy is a framework that enables database data to be seamlessly intercepted and logged with no code changes to the application.It logs all JDBC transactions for any Java application.
+- [p6spy](https://github.com/p6spy/p6spy) - Framework that enables all JDBC transactions to be logged.
 - [SLF4J](https://www.slf4j.org) - Abstraction layer/simple logging facade.
 - [tinylog](http://www.tinylog.org) - Lightweight logging framework with static logger class.
 - [Tracer](https://github.com/zalando/tracer) - Call tracing and log correlation in distributed systems.


### PR DESCRIPTION
P6Spy is application which acts a middle-man in between different ORM solutions and the JDBC. It logs all of the JDBC queries which are usually generated by ORMs such as hibernate. 

It enables easy debugging in situations related to Database as Hibernate and other ORMs provide query logging without values. 

Example : 
This is an example taken from [MKYONG ](http://www.mkyong.com). 
Hibernate Query : 
`insert into mkyong.stock_transaction (CHANGE, CLOSE, DATE, OPEN, STOCK_ID, VOLUME) 
values (?, ?, ?, ?, ?, ?)|`

After Adding P6Spy : 
`insert into mkyong.stock_transaction (CHANGE, CLOSE, DATE, OPEN, STOCK_ID, VOLUME) 
values (10.0, 1.1, '2009-12-30', 1.2, 11, 1000000)`


In Production this gets abit more complex and P6 spy helps massively. I would like to be a part of this **awesome** guide.