### PR TITLE
Add doov library in the bean mapping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Frameworks that ease bean mapping.*
 
+- [dOOv](https://github.com/doov-io/doov) - dOOv is a fluent API for typesafe domain model validation and mapping. It uses annotations, code generation and a type safe DSL to make bean validation and mapping fast and easy.
 - [Dozer](https://github.com/DozerMapper/dozer) - Mapper that copies data from one object to another using annotations and API or XML configuration.
 - [JMapper](https://jmapper-framework.github.io/jmapper-core) - Uses byte code manipulation for lightning-fast mapping. Supports annotations and API or XML configuration.
 - [MapStruct](https://github.com/mapstruct/mapstruct) - Code generator that simplifies mappings between different bean types, based on a convention-over-configuration approach.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Frameworks that ease bean mapping.*
 
-- [dOOv](https://github.com/doov-io/doov) - dOOv is a fluent API for typesafe domain model validation and mapping. It uses annotations, code generation and a type safe DSL to make bean validation and mapping fast and easy.
+- [dOOv](https://github.com/doov-io/doov) - Provides fluent API for typesafe domain model validation and mapping. It uses annotations, code generation and a type safe DSL to make bean validation and mapping fast and easy.
 - [Dozer](https://github.com/DozerMapper/dozer) - Mapper that copies data from one object to another using annotations and API or XML configuration.
 - [JMapper](https://jmapper-framework.github.io/jmapper-core) - Uses byte code manipulation for lightning-fast mapping. Supports annotations and API or XML configuration.
 - [MapStruct](https://github.com/mapstruct/mapstruct) - Code generator that simplifies mappings between different bean types, based on a convention-over-configuration approach.


### PR DESCRIPTION
- Uses code generation to generate a fast and type-safe DSL (like jOOQ) for the validation and mapping of beans
- Enables fluent and clean mapping code `map(userBirthdate).using(d -> yearsBetween(d, now())).to(accountAge)` (see https://github.com/doov-io/doov#mapping)
- Instantiates a syntax tree for each mapping element that can be printed `When user age at 'today' greater or equals '18' ...` (see https://github.com/doov-io/doov#syntax-tree)
- Provides assertion library with AssertJ (see https://github.com/doov-io/doov#testing)
- Actively maintained