### PR TITLE
Add Lingua language detection library

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [CogCompNLP](https://github.com/CogComp/cogcomp-nlp) - Provides common annotators for plain text input.
 - [CoreNLP](https://nlp.stanford.edu/software/corenlp.shtml) - Provides a set of fundamental tools for tasks like tagging, named entity recognition, and sentiment analysis.
 - [DKPro](https://dkpro.github.io) - Collection of reusable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
-- [Lingua](https://github.com/pemistahl/lingua) - A natural language detection library, especially suited for short paragraphs of text.
+- [Lingua](https://github.com/pemistahl/lingua) - Natural language detection library, especially suited for short paragraphs of text.
 - [LingPipe](http://alias-i.com/lingpipe) - Toolkit for tasks ranging from POS tagging to sentiment analysis.
 
 ### Networking

--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [CogCompNLP](https://github.com/CogComp/cogcomp-nlp) - Provides common annotators for plain text input.
 - [CoreNLP](https://nlp.stanford.edu/software/corenlp.shtml) - Provides a set of fundamental tools for tasks like tagging, named entity recognition, and sentiment analysis.
 - [DKPro](https://dkpro.github.io) - Collection of reusable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
+- [Lingua](https://github.com/pemistahl/lingua) - A natural language detection library, especially suited for short paragraphs of text
 - [LingPipe](http://alias-i.com/lingpipe) - Toolkit for tasks ranging from POS tagging to sentiment analysis.
 
 ### Networking

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [CogCompNLP](https://github.com/CogComp/cogcomp-nlp) - Provides common annotators for plain text input.
 - [CoreNLP](https://nlp.stanford.edu/software/corenlp.shtml) - Provides a set of fundamental tools for tasks like tagging, named entity recognition, and sentiment analysis.
 - [DKPro](https://dkpro.github.io) - Collection of reusable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
-- [Lingua](https://github.com/pemistahl/lingua) - A natural language detection library, especially suited for short paragraphs of text
+- [Lingua](https://github.com/pemistahl/lingua) - A natural language detection library, especially suited for short paragraphs of text.
 - [LingPipe](http://alias-i.com/lingpipe) - Toolkit for tasks ranging from POS tagging to sentiment analysis.
 
 ### Networking


### PR DESCRIPTION
Hi, I've written a natural language detection library named _Lingua_ that focuses on language detection of very short paragraphs of text starting at 5 characters. This is a problem for similar other libraries such as Apache Tika which work best for entire sentences. It is written in Kotlin but can be used in any Java 6+ software as well.

https://github.com/pemistahl/lingua/

According to your contribution guidelines, it fulfills aspects (c) and (d). It's still a very young library but with quality, usefulness and usability in mind. The list of supported languages will be extended in the near future. 

I think it's a useful addition to this list and I would be happy if you included my library in here.

Thank you.
