### PR TITLE
add brpc-java to networking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [TLS Channel](https://github.com/marianobarrios/tls-channel) - Implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly.
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141.
+- [brpc-java](https://github.com/baidu/brpc-java) - Java implementation for Baidu RPC, multi-protocol & high performance RPC.
 
 ### ORM
 

--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ A curated list of awesome Java frameworks, libraries and software.
 *Libraries for building network servers.*
 
 - [AkkaGRPC](https://github.com/akka/akka-grpc) - Support for building streaming gRPC servers and clients on top of Akka Streams.
+- [brpc-java](https://github.com/baidu/brpc-java) - Java implementation for Baidu RPC, multi-protocol & high performance RPC.
 - [Comsat](https://github.com/puniverse/comsat) - Integrates standard Java web-related APIs with Quasar fibers and actors.
 - [Dubbo](https://github.com/alibaba/dubbo) - High-performance RPC framework.
 - [Finagle](https://github.com/twitter/finagle) - Extensible RPC system for constructing high-concurrency servers. It implements uniform client and server APIs for several protocols, and is protocol-agnostic to simplify implementation of new protocols.
@@ -665,7 +666,6 @@ A curated list of awesome Java frameworks, libraries and software.
 - [TLS Channel](https://github.com/marianobarrios/tls-channel) - Implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly.
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141.
-- [brpc-java](https://github.com/baidu/brpc-java) - Java implementation for Baidu RPC, multi-protocol & high performance RPC.
 
 ### ORM
 


### PR DESCRIPTION
brpc-java is java implementation of brpc (https://github.com/apache/incubator-brpc).
brpc-java is maintained by baidu.com, and widely used in baidu.com. 
the main feature are:
1. support multi-protocol, and can be easily extend to arbitrary protocol.
2. extremely high performance.
3. the core jar and spring support is separated.
4. support multi naming type, and can be easily extend to arbitrary naming service.
....
