### PR TITLE
Include Manifold

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [JavaParser](https://github.com/javaparser/javaparser) - Parse, modify and generate Java code.
 - [JavaSymbolSolver](https://github.com/javaparser/javasymbolsolver) - A symbol solver for Java.
 - [JRebel ![c]](https://zeroturnaround.com/software/jrebel) - Instantly reloads code and configuration changes without redeploys.
-- [Manifold](http://manifold.systems/) - A single jar that re-energizes Java with powerful features like Type-safe Metaprogramming (e.g. GraphQL- or JSON Schema-based API or domain models), Structural Typing (think any dynamic language), and Extension Methods (think Kotlin).
+- [Manifold](https://manifold.systems) - Re-energizes Java with powerful features like type-safe metaprogramming, structural typing and extension methods.
 - [NoException](https://noexception.machinezoo.com) - Allows checked exceptions in functional interfaces and converts exceptions to Optional return.
 - [SneakyThrow](https://github.com/rainerhahnekamp/sneakythrow) - Ignores checked exceptions without bytecode manipulation. Can also be used inside Java 8 stream operations.
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [JavaParser](https://github.com/javaparser/javaparser) - Parse, modify and generate Java code.
 - [JavaSymbolSolver](https://github.com/javaparser/javasymbolsolver) - A symbol solver for Java.
 - [JRebel ![c]](https://zeroturnaround.com/software/jrebel) - Instantly reloads code and configuration changes without redeploys.
+- [Manifold](http://manifold.systems/) - A single jar that re-energizes Java with powerful features like Type-safe Metaprogramming (e.g. GraphQL- or JSON Schema-based API or domain models), Structural Typing (think any dynamic language), and Extension Methods (think Kotlin).
 - [NoException](https://noexception.machinezoo.com) - Allows checked exceptions in functional interfaces and converts exceptions to Optional return.
 - [SneakyThrow](https://github.com/rainerhahnekamp/sneakythrow) - Ignores checked exceptions without bytecode manipulation. Can also be used inside Java 8 stream operations.
 


### PR DESCRIPTION
The **Manifold** is filling too many gaps (that almost every Java programmer wished to bridge, at least once in their lifetime) to not be included into this list. =)

It is a single jar that uniquely combines such powerful features as **Type-safe Metaprogramming** (e.g. GraphQL- or JSON Schema-based API or domain models), **Structural Typing** (think any dynamic language), **Extension Methods** (think Kotlin) and more. An _IntelliJ IDEA plugin_ is here as well for a better developer experience.

The overall lib design (and metaprogramming focus) rethinks the code instrumentation and generation process. There is also a _dynamic mode_, that allows it to compile and load resources (e.g. JSON Schema files) into the corresponding classes at runtime. In contrast, an annotation-based `jsonschema2pojo` simply won't do it without re-compilation. All this makes it a completely different beast comparing to other Java code generators.

The category — _Development: Augmentation of the development process at a fundamental level_ — was chosen deliberately. Manifold tends to shift a statically compiled and type enclosed Java development paradigm towards the "everything is data" way of thinking and flexible yet static typing approach.

**Other things worth mentioning:**
- It matured and moved into the `1.x` releases stage a week ago or so, thus it seems to be ready for a wider adoption.
- Library's author is enthusiastic, communicable and responsible, and the community is active and welcoming.
- The license is "Apache License, Version 2.0".