### PR TITLE
Restore "Bytecode Manipulation" entry in Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Projects](#projects)
   - [Bean Mapping](#bean-mapping)
   - [Build](#build)
+  - [Bytecode Manipulation](#bytecode-manipulation)
   - [Caching](#caching)
   - [CLI](#cli)
   - [Cluster Management](#cluster-management)


### PR DESCRIPTION
This seems removed in cff1cf989854d4de7389e654fa413c48469c43db accidentally.