### PR TITLE
Added Image-Comparison library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Thumbnailator](https://github.com/coobird/thumbnailator) - High-quality thumbnail generation library.
 - [TwelveMonkeys](https://github.com/haraldk/TwelveMonkeys) - Collection of plugins that extend the number of supported image file formats.
 - [ZXing](https://github.com/zxing/zxing) - Multi-format 1D/2D barcode image processing library.
-- [image-comparison](https://github.com/romankh3/image-comparison) - Java Library that compares 2 images with the same sizes and shows the differences visually by drawing rectangles. Some parts of the image can be excluded from the comparison. Can be used for automation qa tests.
+- [image-comparison](https://github.com/romankh3/image-comparison) - Compares two images with the same sizes and shows the differences visually by drawing rectangles.
 
 ### JSON
 

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Thumbnailator](https://github.com/coobird/thumbnailator) - High-quality thumbnail generation library.
 - [TwelveMonkeys](https://github.com/haraldk/TwelveMonkeys) - Collection of plugins that extend the number of supported image file formats.
 - [ZXing](https://github.com/zxing/zxing) - Multi-format 1D/2D barcode image processing library.
+- [image-comparison](https://github.com/romankh3/image-comparison) - Java Library that compares 2 images with the same sizes and shows the differences visually by drawing rectangles. Some parts of the image can be excluded from the comparison. Can be used for automation qa tests.
 
 ### JSON
 


### PR DESCRIPTION
Added [image-comparison](https://github.com/romankh3/image-comparison) library. This library is published on Maven Central and can be used as a dependency.
It's a unique project because it compares 2 images with the same sizes and shows the differences visually by drawing rectangles. Some parts of the image can be excluded from the comparison.

It's not a commercial project.

Best regards.
Roman.
