### PR TITLE
Fix JavaFX URL to point to OpenJFX site instead of Oracle site

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 *Libraries to create modern graphical user interfaces.*
 
-- [JavaFX](https://www.oracle.com/technetwork/java/javase/overview/javafx-overview-2158620.html) - The successor of Swing.
+- [JavaFX](https://wiki.openjdk.java.net/display/OpenJFX/Main) - The successor of Swing.
 - [Scene Builder](https://gluonhq.com/open-source/scene-builder) - Visual layout tool for JavaFX applications.
 - [SWT](https://www.eclipse.org/swt) - The Standard Widget Toolkit, a graphical widget toolkit.
 


### PR DESCRIPTION
Since JavaFX was removed from the JDK the Oracle site on JavaFX currently contains barely any information and mostly links to the JavaFX documentation for Java 8, as well as the main OpenJFX site.
Considering this I find it suitable to change the link destination to the main OpenJFX site.
Although the [OpenJFX community site](https://openjfx.io/) would be another candidate, the main site provides a link to it and other relevant sites, so I figured the main one would be more suitable.