### PR TITLE
Remove LightAdmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,6 @@ A curated list of awesome Java frameworks, libraries and software.
 - [Jimfs](https://github.com/google/jimfs) - In-memory file system.
 - [Joda-Money](http://www.joda.org/joda-money) - Basic currency and money classes and algorithms not provided by the JDK.
 - [JPad](http://jpad.io) - Snippet runner.
-- [LightAdmin](http://lightadmin.org) - Pluggable CRUD UI library for rapid application development.
 - [Maven Wrapper](https://github.com/takari/maven-wrapper) - Analogue of Gradle Wrapper for Maven, allows building projects without installing maven.
 - [Membrane Service Proxy](https://github.com/membrane/service-proxy) - An open-source, reverse-proxy framework written in Java.
 - [MinimalFTP](https://github.com/Guichaguri/MinimalFTP) - Lightweight, small and customizable FTP server.


### PR DESCRIPTION
The site is dead, no activity https://github.com/la-team/light-admin , POC status, build on deprecated technologies (e.g. Spring IO Platform)
