### PR TITLE
Add SmartDec SAST

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [jQAssistant](https://jqassistant.org) - Static code analysis with Neo4J-based query language. (GPL-3.0-only)
 - [NullAway](https://github.com/uber/NullAway) - Eliminates NullPointerExceptions with low build-time overhead.
 - [PMD](https://github.com/pmd/pmd) - Source code analysis for finding bad coding practices.
+- [SmartDec Scanner ![c]](https://smartdecscanner.com/) - SAST tool scans the source code and executable files. Supports more than 30 programming languages.
 - [SonarJava](https://github.com/SonarSource/sonar-java) - Static analyzer for SonarQube & SonarLint. (LGPL-3.0-only)
 - [Sourcetrail ![c]](https://www.sourcetrail.com) - Visual source code navigator.
 - [Spoon](https://github.com/INRIA/spoon) - Library for analyzing and transforming Java source code.


### PR DESCRIPTION
Add information about **SmartDec** to **Code Analysis** section.

SmartDec Scanner is a SAST tool which is capable of identifying vulnerabilities and backdoors (undocumented features). Its distinctive feature is the ability to analyze not only source code but also executables without debug info (i.e. binaries) and to return much better results than when using DAST. The analyzer can test apps written in more than 30 programming languages or that have been compiled into an executable file with one of nine supported extensions, including those for Google Android, Apple iOS, and Apple macOS. SmartDec Scanner also can be easily integrated into a Secure SDLC process.
Moreover, SmartDec Scanner does run a vast variety of checks, automating vulnerability discovery as well as detecting generic errors and discrepancies with recommended code writing practices. Such checks obviously does help Java developers better understand language semantics as well as properties of their code base and ensure guideline acceptance for it.