### PR TITLE
Add reMap in Bean Mapping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [MapStruct](https://github.com/mapstruct/mapstruct) - Code generator that simplifies mappings between different bean types, based on a convention-over-configuration approach.
 - [ModelMapper](https://github.com/jhalterman/modelmapper) - Intelligent object mapping library that automatically maps objects to each other.
 - [Orika](https://github.com/orika-mapper/orika) - JavaBean-mapping framework that recursively copies (among other capabilities) data from one object to another.
+- [reMap](https://github.com/remondis-it/remap) - Lambda & Method Handle-based mapping of objects to objects. Code (no annotations) is only needed when objects have different names.
 - [Selma](https://github.com/xebia-france/selma) - Annotation processor-based bean mapper.
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A curated list of awesome Java frameworks, libraries and software.
 - [MapStruct](https://github.com/mapstruct/mapstruct) - Code generator that simplifies mappings between different bean types, based on a convention-over-configuration approach.
 - [ModelMapper](https://github.com/jhalterman/modelmapper) - Intelligent object mapping library that automatically maps objects to each other.
 - [Orika](https://github.com/orika-mapper/orika) - JavaBean-mapping framework that recursively copies (among other capabilities) data from one object to another.
-- [reMap](https://github.com/remondis-it/remap) - Lambda & Method Handle-based mapping of objects to objects. Code (no annotations) is only needed when objects have different names.
+- [reMap](https://github.com/remondis-it/remap) - Lambda and method handle-based mapping which requires code and not annotations if objects have different names.
 - [Selma](https://github.com/xebia-france/selma) - Annotation processor-based bean mapper.
 
 ### Build


### PR DESCRIPTION
reMap is a code-based declarative bean mapping tool that takes a somewhat different approach than other mappers in its avoidance of annotations and automatic copying when properties match. Integrates well with Spring Boot.
