### PR TITLE
Update Google Truth Link and Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,7 +977,7 @@ A curated list of awesome Java frameworks, libraries and software.
 
 - [AssertJ](https://joel-costigliola.github.io/assertj) - Fluent assertions that improve readability.
 - [JSONAssert](http://jsonassert.skyscreamer.org) - Simplifies testing JSON strings.
-- [Truth](https://github.com/google/truth) - Google's assertion and proposition framework.
+- [Truth](https://truth.dev) - Google's fluent assertion and proposition framework.
 - [XMLUnit](https://github.com/xmlunit/xmlunit) - Simplifies testing for XML output.
 
 #### Miscellaneous


### PR DESCRIPTION
* Link to the project page, instead of the source repo
* Mention that it provides "fluent" assertions - as there is a big difference in usage between fluent assertions and simple (or nested) assertion methods