### PR TITLE
Add yGuard as miscellaneous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ _Everything else._
 - [TypeTools](https://github.com/jhalterman/typetools) - Tools for resolving generic types.
 - [XMLBeam](https://github.com/SvenEwald/xmlbeam) - Processes XML by using annotations or XPath within code.
 - [OctoLinker](https://github.com/OctoLinker/browser-extension) - Browser extension which allows to navigate through code on GitHub more efficiently.
-- [yGuard](https://github.com/yWorks/yGuard) - The open-source Java obfuscation tool working with Ant and Gradle by yWorks.
+- [yGuard](https://github.com/yWorks/yGuard) - Obfuscation via renaming and shrinking.
 
 ### Microservice
 

--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ _Everything else._
 - [TypeTools](https://github.com/jhalterman/typetools) - Tools for resolving generic types.
 - [XMLBeam](https://github.com/SvenEwald/xmlbeam) - Processes XML by using annotations or XPath within code.
 - [OctoLinker](https://github.com/OctoLinker/browser-extension) - Browser extension which allows to navigate through code on GitHub more efficiently.
+- [yGuard](https://github.com/yWorks/yGuard) - The open-source Java obfuscation tool working with Ant and Gradle by yWorks.
 
 ### Microservice
 


### PR DESCRIPTION
I believe this project ticks all the boxes:

- is (as to my knowledge), the only open source obfuscation library for Java, and the only _"competitor"_ to `proGuard` 
- is licensed under `MIT` and freely available
- can be used with a variety of developer resources (`Ant`, `Maven`, `Gradle`)
- has a great deal of documentation and examples available in english language

This PR may be frown upon, because it is essentially self-promotion. However so, I think obfuscation is a **incredibly** useful resource, which justifies this PR just fine.