### PR TITLE
Add jlink.online

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ _Tools that handle the distribution of applications in native formats._
 - [Capsule](http://www.capsule.io) - Simple and powerful packaging and deployment. A fat JAR on steroids, or a "Docker for Java" that supports JVM-optimized containers.
 - [Central Repository](https://search.maven.org) - Largest binary component repository available as a free service to the open-source community. Default used by Apache Maven, and available in all other build tools.
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
+- [jlink.online](https://github.com/cilki/jlink.online) - Builds optimized Java runtimes over HTTP.
 - [Nexus ![c]](https://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.
 - [packr](https://github.com/libgdx/packr) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and Mac OS X.
 - [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - Maven plugin for making self-executing JARs.

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ _Tools that handle the distribution of applications in native formats._
 - [Capsule](http://www.capsule.io) - Simple and powerful packaging and deployment. A fat JAR on steroids, or a "Docker for Java" that supports JVM-optimized containers.
 - [Central Repository](https://search.maven.org) - Largest binary component repository available as a free service to the open-source community. Default used by Apache Maven, and available in all other build tools.
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
-- [jlink.online](https://github.com/cilki/jlink.online) - Builds optimized Java runtimes over HTTP.
+- [jlink.online](https://github.com/cilki/jlink.online) - Builds optimized runtimes over HTTP.
 - [Nexus ![c]](https://www.sonatype.com/nexus/solution-overview) - Binary management with proxy and caching capabilities.
 - [packr](https://github.com/libgdx/packr) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and Mac OS X.
 - [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - Maven plugin for making self-executing JARs.


### PR DESCRIPTION

[jlink.online](https://github.com/cilki/jlink.online) is a microservice that makes it easier to build runtime images for modular applications. It's written in Go, but I think it still belongs here given that it's only useful to the Java crowd.

Thanks for maintaining this list, by the way!