### PR TITLE
Add hate HATEOAS library to json section

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ _Libraries for serializing and deserializing JSON to and from Java objects._
 - [DSL-JSON](https://github.com/ngs-doo/dsl-json) - JSON library with advanced compile time databinding.
 - [Genson](http://genson.io) - Powerful and easy-to-use Java-to-JSON conversion library.
 - [Gson](https://github.com/google/gson) - Serializes objects to JSON and vice versa. Good performance with on-the-fly usage.
+- [hate](https://github.com/blackdoor/hate) - Build hypermedia-friendly objects with HAL (uses jackson).
 - [HikariJSON](https://github.com/brettwooldridge/HikariJSON) - High-performance JSON parser, 2x faster than Jackson.
 - [jackson-modules-java8](https://github.com/FasterXML/jackson-modules-java8) - Set of Jackson modules for Java 8 datatypes and features.
 - [Jackson-datatype-money](https://github.com/zalando/jackson-datatype-money) - Open-source Jackson module to support JSON serialization and deserialization of JavaMoney data types.

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ _Libraries that assist with creating HTTP requests and/or binding responses._
 
 _Libraries that handle serialization to hypermedia types._
 
+- [hate](https://github.com/blackdoor/hate) - Builds hypermedia-friendly objects according to HAL specification.
 - [JSON-LD](https://github.com/jsonld-java/jsonld-java) - JSON-LD implementation.
 - [Siren4J](https://github.com/eserating/siren4j) - Library for the Siren specification.
 
@@ -510,7 +511,6 @@ _Libraries for serializing and deserializing JSON to and from Java objects._
 - [DSL-JSON](https://github.com/ngs-doo/dsl-json) - JSON library with advanced compile time databinding.
 - [Genson](http://genson.io) - Powerful and easy-to-use Java-to-JSON conversion library.
 - [Gson](https://github.com/google/gson) - Serializes objects to JSON and vice versa. Good performance with on-the-fly usage.
-- [hate](https://github.com/blackdoor/hate) - Build hypermedia-friendly objects with HAL (uses jackson).
 - [HikariJSON](https://github.com/brettwooldridge/HikariJSON) - High-performance JSON parser, 2x faster than Jackson.
 - [jackson-modules-java8](https://github.com/FasterXML/jackson-modules-java8) - Set of Jackson modules for Java 8 datatypes and features.
 - [Jackson-datatype-money](https://github.com/zalando/jackson-datatype-money) - Open-source Jackson module to support JSON serialization and deserialization of JavaMoney data types.


### PR DESCRIPTION
Library for creating HAL objects integrated with jackson. Enables users to fulfill the HATEOAS requirement of REST APIs.
