### PR TITLE
adding sql-to-mongo-db-query-converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ _Everything that simplifies interactions with the database._
 - [requery](https://github.com/requery/requery) - Modern, lightweight but powerful object mapping and SQL generator. Easily map to or create databases, or perform queries and updates from any Java-using platform.
 - [Speedment](https://github.com/speedment/speedment) - Database access library that utilizes Java 8's Stream API for querying.
 - [sql2o](https://www.sql2o.org) - Thin JDBC wrapper that simplifies database access and provides simple mapping of ResultSets to POJOs.
+- [sql-to-mongo-db-query-converter](https://github.com/vincentrussell/sql-to-mongo-db-query-converter) - Helps you build quieres for MongoDb based on Queries provided in SQL.
 - [Vibur DBCP](https://www.vibur.org) - JDBC connection pool library with advanced performance monitoring capabilities.
 - [Xodus](https://jetbrains.github.io/xodus/) - Highly concurrent transactional schema-less and ACID-compliant embedded database.
 


### PR DESCRIPTION
sql-to-mongo-db-query-converter helps you build quieres for MongoDb based on Queries provided in SQL.
