### PR TITLE
add Freemarker template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ _Servers specifically used to deploy applications._
 
 _Tools that substitute expressions in a template._
 
+- [Freemarker](https://freemarker.apache.org) - Library to generate text output (HTML web pages, e-mails, configuration files, source code, etc.) based on templates and changing data.
 - [Handlebars.java](https://jknack.github.io/handlebars.java/) - Logicless and semantic Mustache templates.
 - [Jade4J](https://github.com/neuland/jade4j) - Implementation of Pug (formerly known as Jade).
 - [Jtwig](http://jtwig.org) - Modular, configurable and fully tested template engine.


### PR DESCRIPTION
Apache Feeemarker is actual (supported by Spring Boot out of the box) and alive (latest update is 2020-03-05) template engine.
Description is taken from first sentence on official site: https://freemarker.apache.org