### PR TITLE
Add Mini2Dx game framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ _Frameworks that support the development of games._
 - [jMonkeyEngine](https://jmonkeyengine.org) - Game engine for modern 3D development.
 - [libGDX](https://libgdx.badlogicgames.com) - All-round cross-platform, high-level framework.
 - [LWJGL](https://www.lwjgl.org) - Robust framework that abstracts libraries like OpenGL/CL/AL.
-- [Mini2Dx](https://mini2dx.org) - An open-source beginner-friendly, master-ready framework for rapidly prototyping and building 2D games in Java. 
+- [Mini2Dx](https://mini2dx.org) - Beginner-friendly, master-ready framework for rapidly prototyping and building 2D games. 
 
 ### Geospatial
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ _Frameworks that support the development of games._
 - [jMonkeyEngine](https://jmonkeyengine.org) - Game engine for modern 3D development.
 - [libGDX](https://libgdx.badlogicgames.com) - All-round cross-platform, high-level framework.
 - [LWJGL](https://www.lwjgl.org) - Robust framework that abstracts libraries like OpenGL/CL/AL.
-- [Mini2Dx](https://mini2dx.org) - Beginner-friendly, master-ready framework for rapidly prototyping and building 2D games. 
+- [Mini2Dx](https://mini2dx.org) - Beginner-friendly, master-ready framework for rapidly prototyping and building 2D games.
 
 ### Geospatial
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ _Frameworks that support the development of games._
 - [jMonkeyEngine](https://jmonkeyengine.org) - Game engine for modern 3D development.
 - [libGDX](https://libgdx.badlogicgames.com) - All-round cross-platform, high-level framework.
 - [LWJGL](https://www.lwjgl.org) - Robust framework that abstracts libraries like OpenGL/CL/AL.
+- [Mini2Dx](https://mini2dx.org) - An open-source beginner-friendly, master-ready framework for rapidly prototyping and building 2D games in Java. 
 
 ### Geospatial
 


### PR DESCRIPTION
Mini2dx is an excellent game framework for building 2d games with a simple to use api. There are many optional plugins for more advanced features similar to libgdx. It can even use most libgdx extensions.

The new 2.0 version is building in a way to cross build for console deployment. This sets it apart the most from other java frameworks.

It also boasts a custom ui system and embedded scripting library miniscript.