### PR TITLE
Added SSLContext Kickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [OACC](http://oaccframework.org) - Provides permission-based authorization services.
 - [pac4j](https://github.com/pac4j/pac4j) - Security engine.
 - [SecurityBuilder](https://github.com/tersesystems/securitybuilder) - Fluent Builder API for JCA and JSSE classes and especially X.509 certificates.
+- [SSLContext-Kickstart](https://github.com/Hakky54/sslcontext-kickstart) - Highlevel SSLContext builder for configuring Http clients with SSL/TLS.
 - [Themis](https://github.com/cossacklabs/themis) - Multi-platform high-level cryptographic library provides easy-to-use encryption for protecting sensitive data: secure messaging with forward secrecy, secure data storage (AES256GCM); suits for building end-to-end encrypted applications.
 - [Tink](https://github.com/google/tink) - Provides a simple and misuse-proof API for common cryptographic tasks.
 

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [OACC](http://oaccframework.org) - Provides permission-based authorization services.
 - [pac4j](https://github.com/pac4j/pac4j) - Security engine.
 - [SecurityBuilder](https://github.com/tersesystems/securitybuilder) - Fluent Builder API for JCA and JSSE classes and especially X.509 certificates.
-- [SSLContext-Kickstart](https://github.com/Hakky54/sslcontext-kickstart) - Highlevel SSLContext builder for configuring Http clients with SSL/TLS.
+- [SSLContext-Kickstart](https://github.com/Hakky54/sslcontext-kickstart) - High-level SSL context builder for configuring HTTP clients with SSL/TLS.
 - [Themis](https://github.com/cossacklabs/themis) - Multi-platform high-level cryptographic library provides easy-to-use encryption for protecting sensitive data: secure messaging with forward secrecy, secure data storage (AES256GCM); suits for building end-to-end encrypted applications.
 - [Tink](https://github.com/google/tink) - Provides a simple and misuse-proof API for common cryptographic tasks.
 


### PR DESCRIPTION
SSLContext Kickstart provides a high-level factory class for configuring a http client to communicate over SSL/TLS for one way authentication or two way authentication. It has the ability to easily load any amount of key and trust material. It is lightweight as it has almost none transitive dependencies.
