### PR TITLE
Add mhewedy/sftp-utils under network section

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,8 @@ _Libraries for building network servers._
 - [TLS Channel](https://github.com/marianobarrios/tls-channel) - Implements a ByteChannel interface over SSLEngine, enabling easy-to-use (socket-like) TLS.
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly. (LGPL-2.1-only)
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141. (GPL-3.0-only)
+- [sftp-utils](https://github.com/mhewedy/sftp-utils) - Utilities to access sftp via jsch java library
+
 
 ### ORM
 


### PR DESCRIPTION

Please read the CONTRIBUTING.md first. The most important parts regarding the actual entry:

- It makes using the poorly-designed API of jsch library an easy task

