### PR TITLE
Added olivomarco/lc4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ _Libraries that specialize in processing text._
 - [CoreNLP](https://nlp.stanford.edu/software/corenlp.shtml) - Provides a set of fundamental tools for tasks like tagging, named entity recognition, and sentiment analysis. (GPL-3.0-or-later)
 - [DKPro](https://dkpro.github.io) - Collection of reusable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
 - [LingPipe](http://alias-i.com/lingpipe/) - Toolkit for tasks ranging from POS tagging to sentiment analysis.
+- [lc4j](https://github.com/olivomarco/lc4j) - Library to detect the language in which a given text is written.
 
 ### Networking
 


### PR DESCRIPTION
I am adding my github project olivomarco/lc4j which is new to Github but I had hosted that on my website for a very long time. 

I developed this library back in 2005 porting and adapting an existing project from Perl, and over time I know it has been incorporated in some projects. I think it is a good addition to the list because the other NLP libraries do not offer to my knowledge language determination of a snippet of text.