### PR TITLE
Added LogCaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,7 @@ _Libraries that provide custom matchers._
 _Other stuff related to testing._
 
 - [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - TestNG-like data provider/runner for JUnit.
-- [LogCaptor](https://github.com/Hakky54/log-captor) - Captures log entries for unit testing purposes
+- [LogCaptor](https://github.com/Hakky54/log-captor) - Captures log entries for unit testing purposes.
 - [Mutability Detector](https://github.com/MutabilityDetector/MutabilityDetector) - Reports whether instances of a given class are immutable.
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
 - [TestContainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.

--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,7 @@ _Libraries that provide custom matchers._
 _Other stuff related to testing._
 
 - [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - TestNG-like data provider/runner for JUnit.
+- [LogCaptor](https://github.com/Hakky54/log-captor) - Captures log entries for unit testing purposes
 - [Mutability Detector](https://github.com/MutabilityDetector/MutabilityDetector) - Reports whether instances of a given class are immutable.
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
 - [TestContainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.


### PR DESCRIPTION
LogCaptor is a library which will enable you to easily capture logging entries for unit testing purposes. It makes it possible to capture and assert SLF4J logs or other logging frameworks logs. It is very leightweight as it contains only one transitive dependency. Most of the developers dont bother testing log messages as it is time consuming and hard to configure. But if it is made really easy, probably more developers would also test their log messages. It should be painless and fun!

Below is an example use case:
```java
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

public class FooService {

    private static final Logger LOGGER = LoggerFactory.getLogger(FooService.class);

    public void sayHello() {
        LOGGER.info("Keyboard not responding. Press any key to continue...");
        LOGGER.warn("Congratulations, you are pregnant!");
    }

}
```

And the following unit test:
```java
import static org.assertj.core.api.Assertions.assertThat;

import nl.altindag.log.LogCaptor;
import org.junit.jupiter.api.Test;

public class FooServiceShould {

    @Test
    public void logInfoAndWarnMessages() {
        String expectedInfoMessage = "Keyboard not responding. Press any key to continue...";
        String expectedWarnMessage = "Congratulations, you are pregnant!";

        LogCaptor logCaptor = LogCaptor.forClass(FooService.class);

        FooService fooService = new FooService();
        fooService.sayHello();

        // Option 1 to assert logging entries
        assertThat(logCaptor.getInfoLogs()).containsExactly(expectedInfoMessage);
        assertThat(logCaptor.getWarnLogs()).containsExactly(expectedWarnMessage);

        // Option 2 to assert logging entries
        assertThat(logCaptor.getLogs())
                .hasSize(2)
                .containsExactly(expectedInfoMessage, expectedWarnMessage);
    }
}
```