### PR TITLE
Adding awesome-ai-ml-dl: java link to the Awesome section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,7 @@ _Frameworks that handle the communication between the layers of a web applicatio
 
 _Awesome lists related to the Java & JVM ecosystem._
 
+- [Awesome AI/ML/DL: Java](https://github.com/neomatrix369/awesome-ai-ml-dl/blob/master/details/java-jvm.md#java)
 - [Awesome Annotation Processing](https://github.com/gunnarmorling/awesome-annotation-processing)
 - [Awesome Gradle Plugins](https://github.com/ksoichiro/awesome-gradle)
 - [AwesomeJavaFX](https://github.com/mhrimaz/AwesomeJavaFX)


### PR DESCRIPTION
Adding the Java aspect of the Awesome-AI-ML-DL github repo to the Awesome lists section

Related to issue #885 