### PR TITLE
Added Gatekeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [Apache Shiro](https://shiro.apache.org) - Performs authentication, authorization, cryptography and session management.
 - [Bouncy Castle](https://www.bouncycastle.org/java.html) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
 - [Cryptomator](https://cryptomator.org) - Multiplatform, transparent, client-side encryption of files in the cloud. (GPL-3.0-only)
-- [Gatekeeper](https://github.com/Hakky54/gatekeeper) - Guards your publicly accessible internal implementations from being used by library users
+- [Gatekeeper](https://github.com/Hakky54/gatekeeper) - Guards your publicly accessible internal implementations from being used by library users.
 - [Hdiv](https://github.com/hdiv/hdiv) - Runtime application that repels application security risks included in the OWASP Top 10, including SQL injection, cross-site scripting, cross-site request forgery, data tampering, and brute force attacks.
 - [jjwt](https://github.com/jwtk/jjwt) - JSON web token for Java and Android.
 - [Jwks RSA](https://github.com/auth0/jwks-rsa-java) - JSON Web Key Set parser.

--- a/README.md
+++ b/README.md
@@ -922,6 +922,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [Apache Shiro](https://shiro.apache.org) - Performs authentication, authorization, cryptography and session management.
 - [Bouncy Castle](https://www.bouncycastle.org/java.html) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
 - [Cryptomator](https://cryptomator.org) - Multiplatform, transparent, client-side encryption of files in the cloud. (GPL-3.0-only)
+- [Gatekeeper](https://github.com/Hakky54/gatekeeper) - Guards your publicly accessible internal implementations from being used by library users
 - [Hdiv](https://github.com/hdiv/hdiv) - Runtime application that repels application security risks included in the OWASP Top 10, including SQL injection, cross-site scripting, cross-site request forgery, data tampering, and brute force attacks.
 - [jjwt](https://github.com/jwtk/jjwt) - JSON web token for Java and Android.
 - [Jwks RSA](https://github.com/auth0/jwks-rsa-java) - JSON Web Key Set parser.


### PR DESCRIPTION
### Link
[GitHub - Gatekeeper](https://github.com/Hakky54/gatekeeper)

### Short description
Gatekeeper is a library which guards your publicly accessible internal implementations.

### Description
Library maintainers have a hard time to keep internal implementations internal and prevent it to be accessible by library users. The library maintainer cannot easily change internal implementations as it may lead into breaking changes for the library users. A straight forward method for library maintainers would be making classes package protected and accessible through public api's so-called Service classes. Encapsulation internal api's and exposing it through service classes is the preferred way but cannot be achieved in some use cases. Restrictions by Java Modules will not work if the end-user is not using java modules. Gatekeeper will ensure that these internal implementations remain internal by validating the caller. You as a library developer can choose who is allowed to call your classes.