### PR TITLE
Adding commons-networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ _Libraries that specialize in processing text._
 
 _Libraries for building network servers._
 
-- [Commons-networking](https://github.com/CiscoSE/commons-networking/tree/main/commons-networking#commons-networking) - SSE (Server-sent Events) client.
+- [Commons-networking](https://github.com/CiscoSE/commons-networking) - Client for server-sent events (SSE).
 - [Comsat](https://github.com/puniverse/comsat) - Integrates standard Java web-related APIs with Quasar fibers and actors.
 - [Dubbo](https://github.com/apache/dubbo) - High-performance RPC framework.
 - [Grizzly](https://javaee.github.io/grizzly/) - NIO framework. Used as a network layer in Glassfish.

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ _Libraries that specialize in processing text._
 
 _Libraries for building network servers._
 
-- [Commons-networking](https://github.com/CiscoSE/commons-networking) - SSE (Server-sent Events) client. GNMI Utils.
+- [Commons-networking](https://github.com/CiscoSE/commons-networking/tree/main/commons-networking#commons-networking) - SSE (Server-sent Events) client.
 - [Comsat](https://github.com/puniverse/comsat) - Integrates standard Java web-related APIs with Quasar fibers and actors.
 - [Dubbo](https://github.com/apache/dubbo) - High-performance RPC framework.
 - [Grizzly](https://javaee.github.io/grizzly/) - NIO framework. Used as a network layer in Glassfish.

--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ _Libraries that specialize in processing text._
 
 _Libraries for building network servers._
 
+- [Commons-networking](https://github.com/CiscoSE/commons-networking) - SSE (Server-sent Events) client. GNMI Utils.
 - [Comsat](https://github.com/puniverse/comsat) - Integrates standard Java web-related APIs with Quasar fibers and actors.
 - [Dubbo](https://github.com/apache/dubbo) - High-performance RPC framework.
 - [Grizzly](https://javaee.github.io/grizzly/) - NIO framework. Used as a network layer in Glassfish.


### PR DESCRIPTION
Adding commons-networking

Features:

- SSE (Server-sent Events) client


Simple SSE client almost without any dependencies, did not found anything similar online, and not here in this list.

It is used in developments in a similar version.

As it is new and similar implementation not found, it is currently still cannot be widely recommended.

Note: I am the author of this SSE client.
