### PR TITLE
Added "DevProjects" under "Miscellaneous"

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ _Everything else._
 - [TypeTools](https://github.com/jhalterman/typetools) - Tools for resolving generic types.
 - [XMLBeam](https://github.com/SvenEwald/xmlbeam) - Processes XML by using annotations or XPath within code.
 - [yGuard](https://github.com/yWorks/yGuard) - Obfuscation via renaming and shrinking.
+- [DevProjects](https://www.codementor.io/projects/java) - Free community with Java projects to learn Java or help others learn.
 
 ### Mobile Development
 


### PR DESCRIPTION
I recently found DevProjects, a community with all kinds of free coding projects, and added it to Miscellaneous because I've been using the website's projects to practice Java. I'm quite new to Java, so I focus on the easier ones. I personally find the solutions and discussions helpful and think building Java projects is a fun way to learn Java.

If you think it might be a good resource for the community, I personally think it'd be a great addition!