### PR TITLE
Remove sql2o

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ _Everything that simplifies interactions with the database._
 - [Redisson](https://github.com/redisson/redisson) - Allows for distributed and scalable data structures on top of a Redis server.
 - [requery](https://github.com/requery/requery) - Modern, lightweight but powerful object mapping and SQL generator. Easily map to or create databases, or perform queries and updates from any Java-using platform.
 - [Speedment](https://github.com/speedment/speedment) - Database access library that utilizes Java 8's Stream API for querying.
-- [sql2o](https://www.sql2o.org) - Thin JDBC wrapper that simplifies database access and provides simple mapping of ResultSets to POJOs.
 - [Vibur DBCP](https://www.vibur.org) - JDBC connection pool library with advanced performance monitoring capabilities.
 - [Xodus](https://github.com/JetBrains/xodus) - Highly concurrent transactional schema-less and ACID-compliant embedded database.
 


### PR DESCRIPTION
It doesn't support Java above 8, [has no activity](https://github.com/aaberg/sql2o/graphs/contributors) and it's niche is well covered by JDBI (already on the list) 
