### PR TITLE
Add m2cgen for transpiling ML models into Java code

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [DJL](https://djl.ai) - High-level and engine-agnostic framework for deep learning.
 - [H2O ![c]](https://www.h2o.ai) - Analytics engine for statistics over big data.
 - [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
-- [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Java code with zero dependencies.
+- [m2cgen](https://github.com/BayesWitnesses/m2cgen) - CLI tool to transpile models into native code.
 - [oj! Algorithms](https://www.ojalgo.org/) - High-performance mathematics, linear algebra and optimisation needed for data science, machine learning and scientific computing.
 - [Oryx 2](https://github.com/OryxProject/oryx) - Framework for building real-time, large-scale machine learning applications. Includes end-to-end applications for collaborative filtering, classification, regression, and clustering.
 - [Siddhi](https://github.com/siddhi-io/siddhi) - Cloud native streaming and complex event processing engine.

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [DJL](https://djl.ai) - High-level and engine-agnostic framework for deep learning.
 - [H2O ![c]](https://www.h2o.ai) - Analytics engine for statistics over big data.
 - [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
+- [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Java code with zero dependencies.
 - [oj! Algorithms](https://www.ojalgo.org/) - High-performance mathematics, linear algebra and optimisation needed for data science, machine learning and scientific computing.
 - [Oryx 2](https://github.com/OryxProject/oryx) - Framework for building real-time, large-scale machine learning applications. Includes end-to-end applications for collaborative filtering, classification, regression, and clustering.
 - [Siddhi](https://github.com/siddhi-io/siddhi) - Cloud native streaming and complex event processing engine.


### PR DESCRIPTION
<!--
Please read the CONTRIBUTING.md first. The most important parts regarding the actual entry:

- Write about it's unique selling point compared to other projects.
- If it's a commercial project, then mark it as such, e.g. `[Title ![c]](URL)`.
- Ensure that you provide concise and informative descriptions.
- Do not use a description like "A library/project/tool/framework for JSON processing in Java" since all of this is implied.
- Finish the description with a dot.
- Try to order it alphabetically.
-->
`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of Java programming language. Examples of generated Java code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/java).