### PR TITLE
chore: add questdb to database category

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ _Everything that simplifies interactions with the database._
 - [Modality](https://github.com/arkanovicz/modality) - Lightweight ORM with database reverse engineering features.
 - [Spring Data JPA MongoDB Expressions](https://github.com/mhewedy/spring-data-jpa-mongodb-expressions) - Allows you to use MongoDB query language to query your relational database.
 - [Trino](https://trino.io) - Distributed SQL query engine for big data.
+- [QuestDB](https://github.com/questdb/questdb) - High performance  SQL database for time series, supporting InfluxDB line protocol, PostgreSQL, and REST.
 - [QueryStream](https://github.com/querystream/querystream) - Build JPA Criteria queries using a Stream-like API.
 - [Querydsl](http://www.querydsl.com) - Typesafe unified queries.
 - [Realm](https://github.com/realm/realm-java) - Mobile database to run directly inside phones, tablets or wearables.

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ _Everything that simplifies interactions with the database._
 - [Modality](https://github.com/arkanovicz/modality) - Lightweight ORM with database reverse engineering features.
 - [Spring Data JPA MongoDB Expressions](https://github.com/mhewedy/spring-data-jpa-mongodb-expressions) - Allows you to use MongoDB query language to query your relational database.
 - [Trino](https://trino.io) - Distributed SQL query engine for big data.
-- [QuestDB](https://github.com/questdb/questdb) - High performance  SQL database for time series, supporting InfluxDB line protocol, PostgreSQL, and REST.
+- [QuestDB](https://github.com/questdb/questdb) - High-performance SQL database for time series. Supports InfluxDB line protocol, PostgreSQL wire protocol, and REST.
 - [QueryStream](https://github.com/querystream/querystream) - Build JPA Criteria queries using a Stream-like API.
 - [Querydsl](http://www.querydsl.com) - Typesafe unified queries.
 - [Realm](https://github.com/realm/realm-java) - Mobile database to run directly inside phones, tablets or wearables.


### PR DESCRIPTION
- Add QuestDB to the database category

> If it's a commercial project, then mark it as such, e.g. `[Title ![c]](URL)`.

Hi, QuestDB at the current stage is not commercialized, but in the future perhaps will be. Should I mark it? 
Thanks a lot for maintaining this nice list! 

