### PR TITLE
Add Jollyday to Date Time category

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ _Libraries related to handling date and time._
 - [iCal4j](https://github.com/ical4j/ical4j) - Parse and build iCalendar [RFC 5545](https://tools.ietf.org/html/rfc5545) data models.
 - [ThreeTen-Extra](https://github.com/ThreeTen/threeten-extra) - Additional date-time classes that complement those in JDK 8.
 - [Time4J](https://github.com/MenoData/Time4J) - Advanced date and time library. (LGPL-2.1-only)
+- [Jollyday](http://jollyday.sourceforge.net) - API to determines the holidays for a given year, country/name and eventually state/region.
 
 ### Dependency Injection
 


### PR DESCRIPTION
The Jollyday  API determines the holidays for a given year, country/name and eventually state/region. The holiday data is stored in XML files (one for each country) and will be read from the classpath. You can provide your own holiday calendar XML file or use any of the provided ones. Currently there are 63 countries supported like the following: United States, most european countries, Russia, India, Australia. Besides those there will be more special calendars like ...