### PR TITLE
Add JPA Buddy to Code Generators category

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ _Tools that generate patterns for repetitive code in order to reduce verbosity a
 - [JavaPoet](https://github.com/square/javapoet) - API to generate source files.
 - [JHipster](https://github.com/jhipster/generator-jhipster) - Yeoman source code generator for Spring Boot and AngularJS.
 - [Joda-Beans](https://www.joda.org/joda-beans/) - Small framework that adds queryable properties to Java, enhancing JavaBeans.
+- [JPA Buddy ![c]](https://www.jpa-buddy.com) - Plugin for IntelliJ IDEA. Provides visual tools for generating JPA entities, Spring Data JPA repositories, Liquibase changelogs and SQL scripts. Offers automatic Liquibase/Flyway script generation by comparing model to DB, and reverse engineering JPA entities from DB tables.
 - [Lombok](https://projectlombok.org) - Code generator that aims to reduce verbosity.
 - [Record-Builder](https://github.com/Randgalt/record-builder) - Companion builder class, withers and templates for Java records.
 - [Telosys](https://www.telosys.org/) - Simple and light code generator available as an Eclipse Plugin and also as a CLI.


### PR DESCRIPTION
JPA Buddy is a plugin for IntelliJ IDEA that provides visual tools for generating JPA entities, Spring Data JPA repositories, Liquibase changelogs and SQL scripts. It also offers automatic Liquibase/Flyway script generation by comparing model to DB, and reverse engineering JPA entities from DB tables.

It has over 1 million downloads from the JetBrains Marketplace: https://plugins.jetbrains.com/plugin/15075-jpa-buddy
It also offers some unique features, e.g. generating Liquibase/Flyway migration scripts by comparing the JPA entities to the target DB.
