### PR TITLE
Added link to jDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ _Tools that handle the distribution of applications in native formats._
 - [Getdown](https://github.com/threerings/getdown) - A system for deploying Java applications to end-user computers and keeping them up to date. Developed as an alternative to Java Web Start.
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
 - [JavaPackager](https://github.com/fvarrui/JavaPackager) - Maven and Gradle plugin which provides an easy way to package Java applications in native Windows, Mac OS X or GNU/Linux executables, and generate installers for them.
-- [jDeploy](https://www.jdeploy.com) - Deploy Java desktop apps as native Mac, Windows, and Linux bundles.
+- [jDeploy](https://www.jdeploy.com) - Deploy desktop apps as native Mac, Windows or Linux bundles.
 - [jlink.online](https://github.com/cilki/jlink.online) - Builds optimized runtimes over HTTP.
 - [Nexus ![c]](https://www.sonatype.com) - Binary management with proxy and caching capabilities.
 - [packr](https://github.com/libgdx/packr) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and macOS.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ _Tools that handle the distribution of applications in native formats._
 - [Getdown](https://github.com/threerings/getdown) - A system for deploying Java applications to end-user computers and keeping them up to date. Developed as an alternative to Java Web Start.
 - [IzPack](http://izpack.org) - Setup authoring tool for cross-platform deployments.
 - [JavaPackager](https://github.com/fvarrui/JavaPackager) - Maven and Gradle plugin which provides an easy way to package Java applications in native Windows, Mac OS X or GNU/Linux executables, and generate installers for them.
+- [jDeploy](https://www.jdeploy.com) - Deploy Java desktop apps as native Mac, Windows, and Linux bundles.
 - [jlink.online](https://github.com/cilki/jlink.online) - Builds optimized runtimes over HTTP.
 - [Nexus ![c]](https://www.sonatype.com) - Binary management with proxy and caching capabilities.
 - [packr](https://github.com/libgdx/packr) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and macOS.


### PR DESCRIPTION
jDeploy simplifies the deployment of Java desktop apps greatly.  See [hackernews thread](https://news.ycombinator.com/item?id=30340503#30345882) for some discussion and reception by the community.