### PR TITLE
Added 140 second ducklings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,7 +1186,7 @@ _Books that made a big impact and are still worth reading._
 
 _Something to look at or listen to while programming._
 
-- [140 Second Ducklings](https://twitter.com/debugagent/status/1491075324805001219?s=20&t=pJat2j-HN-iRfY3CY5f6qQ) series of short twitter videos explaining Java debugging in depth
+- [140 Second Ducklings](https://twitter.com/debugagent/status/1491075324805001219?s=20&t=pJat2j-HN-iRfY3CY5f6qQ) - Short videos on Twitter explaining Java debugging in depth.
 - [A Bootiful Podcast](https://bootifulpodcast.fm)
 - [Inside Java](https://inside.java/podcast) (Official)
 - [Java Off Heap](http://www.javaoffheap.com)

--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,7 @@ _Books that made a big impact and are still worth reading._
 
 _Something to look at or listen to while programming._
 
+- [140 Second Ducklings](https://twitter.com/debugagent/status/1491075324805001219?s=20&t=pJat2j-HN-iRfY3CY5f6qQ) series of short twitter videos explaining Java debugging in depth
 - [A Bootiful Podcast](https://bootifulpodcast.fm)
 - [Inside Java](https://inside.java/podcast) (Official)
 - [Java Off Heap](http://www.javaoffheap.com)


### PR DESCRIPTION
I added the "140 Second Ducklings" which is a unique resource I didn't see elsewhere. It is self promotion since I created it but it's 100% free.

The ducklings are short 140 second videos that explain a concept fully. In these I explain debugging and teach concepts that the vast majority of Java developers aren't aware of: Maker objects, renderers (in debuggers), tracepoints etc. 