### PR TITLE
Add Javalin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,7 @@ _Frameworks that handle the communication between the layers of a web applicatio
 - [Blade](https://github.com/lets-blade/blade) - Lightweight, modular framework that aims to be elegant and simple.
 - [Bootique](https://bootique.io) - Minimally opinionated framework for runnable apps.
 - [Firefly](http://www.fireflysource.com) - Asynchronous framework for rapid development of high-performance web application.
+- [Javalin](https://javalin.io/) - A simple, lightweight and flexible framework for lightweight web applications.
 - [Jooby](http://www.jooby.org) - Scalable, fast and modular micro-framework that offers multiple programming models.
 - [Ninja](http://www.ninjaframework.org) - Full-stack web framework.
 - [Pippo](http://www.pippo.ro) - Small, highly modularized, Sinatra-like framework.


### PR DESCRIPTION
Javalin is a common-used, minimal purpose web framwork for creating simple and lightweight backends. 