### PR TITLE
Add Xtend

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ _Augmentation of the development process at a fundamental level._
 - [NoException](https://noexception.machinezoo.com) - Allows checked exceptions in functional interfaces and converts exceptions to Optional return.
 - [SneakyThrow](https://github.com/rainerhahnekamp/sneakythrow) - Ignores checked exceptions without bytecode manipulation. Can also be used inside Java 8 stream operations.
 - [Tail](https://kag0.github.io/tail) - Enable infinite recursion using tail call optimization.
+- [Xtend](https://xtend-lang.org) - Xtend is a flexible and expressive dialect of Java, which compiles into readable Java 8 compatible source code.
 
 ### Distributed Applications
 


### PR DESCRIPTION
Xtend is an older Java dialect, often used in connection with Xtext for compiler generation. 