### PR TITLE
Add Curator Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ _Libraries that provide external configuration._
 - [cfg4j](https://github.com/cfg4j/cfg4j) - Modern configuration library for distributed apps written in Java.
 - [config](https://github.com/lightbend/config) - Configuration library supporting Java properties, JSON or its human optimized superset HOCON.
 - [Configurate](https://github.com/SpongePowered/Configurate) - Configuration library with support for various configuration formats and transformations.
+- [Curator Framework](https://curator.apache.org/) - Apache Curator is a Java/JVM client library for Apache ZooKeeper.
 - [dotenv](https://github.com/shyiko/dotenv) - Twelve-factor configuration library which uses environment-specific files.
 - [Externalized Properties](https://github.com/joeljeremy7/externalized-properties) - Lightweight but powerful configuration library which supports resolution of properties from external sources and an extensible post-processing/conversion mechanism.
 - [ini4j](http://ini4j.sourceforge.net) - Provides an API for handling Windows' INI files.


### PR DESCRIPTION
The only well-known framework for interaction with Apache ZooKeeper in Java. Since ZooKeeper is part of the list, there also has to be an API. 