### PR TITLE
Move Recaf from IDE to Bytecode Manipulation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ _Libraries to manipulate bytecode programmatically._
 - [Javassist](https://github.com/jboss-javassist/javassist) - Tries to simplify bytecode editing.
 - [Mixin](https://github.com/SpongePowered/Mixin) - Manipulate bytecode at runtime using real Java code.
 - [Perses](https://github.com/nicolasmanic/perses) - Dynamically injects failure/latency at the bytecode level according to principles of chaos engineering.
+- [Recaf](https://www.coley.software/Recaf/) - JVM reverse engineering toolkit, essentially an IDE for Java bytecode.
 
 ### Caching
 
@@ -501,7 +502,6 @@ _Integrated development environments that try to simplify several aspects of dev
 - [IntelliJ IDEA ![c]](https://www.jetbrains.com/idea/) - Supports many JVM languages and provides good options for Android development. The commercial edition targets the enterprise sector.
 - [jGRASP](https://www.jgrasp.org) - Created to provide software visualizations that work in conjunction with the debugger such as Control Structure Diagrams, UML class diagrams and Object Viewer.
 - [NetBeans](https://netbeans.apache.org) - Provides integration for several Java SE and EE features, from database access to HTML5.
-- [Recaf](https://www.coley.software/Recaf/) - Bytecode editor.
 - [Visual Studio Code](https://code.visualstudio.com/docs/languages/java) - Provides Java support for lightweight projects with a simple, modern workflow by using extensions from the internal marketplace.
 
 ### Imagery


### PR DESCRIPTION
## What's changed

Recaf may be visually similar to an IDE but it is a bytecode editor and should be in the bytecode section. So It's been moved from `IDE` into `Bytecode Manipulation`.

## Why?

Recaf is jokingly referred to as an IDE among users in its community due to the layout and features of the UI. But it is a bytecode editor and being in the bytecode section is a more accurate representation of its purpose. Plus the prior description was short and under-describing its capabilities.