### PR TITLE
added tigerprof to code analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ _Tools that provide metrics and quality measurements._
 - [SonarJava](https://github.com/SonarSource/sonar-java) - Static analyzer for SonarQube & SonarLint. (LGPL-3.0-only)
 - [Spoon](https://github.com/INRIA/spoon) - Library for analyzing and transforming Java source code.
 - [Spotbugs](https://github.com/spotbugs/spotbugs) - Static analysis of bytecode to find potential bugs. (LGPL-2.1-only)
+- [Tigerprof](https://github.com/djinn/tigerprof) - Performance tool which profiles. Useful in conjugation with Flamegraph
 
 ### Code Coverage
 


### PR DESCRIPTION
tigerprof is open source performance tool which uses JVM Tooling interface to create trace points. It is useful in conjugation with Flamegraph. 