### PR TITLE
Add Error Prone Support to Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ _Tools that provide metrics and quality measurements._
 
 - [Checkstyle](https://github.com/checkstyle/checkstyle) - Static analysis of coding conventions and standards. (LGPL-2.1-or-later)
 - [Error Prone](https://github.com/google/error-prone) - Catches common programming mistakes as compile-time errors.
+- [Error Prone Support](https://github.com/PicnicSupermarket/error-prone-support) - Error Prone extensions: extra bug checkers and a large battery of Refaster templates.
 - [Infer](https://github.com/facebook/infer) - Modern static analysis tool for verifying the correctness of code.
 - [jQAssistant](https://jqassistant.org) - Static code analysis with Neo4J-based query language. (GPL-3.0-only)
 - [NullAway](https://github.com/uber/NullAway) - Eliminates NullPointerExceptions with low build-time overhead.


### PR DESCRIPTION
Error Prone Support is the first library that open sources Refaster templates on top of https://github.com/google/error-prone. Additionally, there's been significant work done to make it super simple to rewrite Java code at scale.