### PR TITLE
Add HertzBeat to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ _Tools that monitor applications in production._
 - [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
 - [Failsafe Actuator](https://github.com/zalando/failsafe-actuator) - Out of the box monitoring of Failsafe Circuit Breaker in Spring-Boot environment.
 - [Glowroot](https://glowroot.org) - Open-source Java APM.
+- [HertzBeat](https://github.com/dromara/hertzbeat) - An open-source real-time monitoring system with custom-monitor and agentless.
 - [inspectIT](https://www.inspectit.rocks) - Captures detailed run-time information via hooks that can be changed on the fly. It supports tracing over multiple systems via the OpenTracing API and can correlate the data with end user monitoring.
 - [Instrumental ![c]](https://instrumentalapp.com) - Real-time Java application performance monitoring. A commercial service with free development accounts.
 - [JavaMelody](https://github.com/javamelody/javamelody) - Performance monitoring and profiling.


### PR DESCRIPTION
### Application name / category

[HertzBeat](https://github.com/dromara/hertzbeat) / Monitoring

### Source URL 

https://github.com/dromara/hertzbeat

### Why it is awesome

HertzBeat is an open source, real-time monitoring system with custom-monitor and agentless. Written in Java. Support jvm, jmx, web service, database, os, middleware and more. Popular in [reddit](https://www.reddit.com/r/selfhosted/comments/wsw124/hertzbeat_an_opensource_monitoring_system_with/). 