### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,7 @@ _Libraries that handle security, authentication, authorization or session manage
 
 - [Apache Shiro](https://shiro.apache.org) - Performs authentication, authorization, cryptography and session management.
 - [Bouncy Castle](https://www.bouncycastle.org/java.html) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - Extracts server certificates.
 - [Cryptomator](https://cryptomator.org) - Multiplatform, transparent, client-side encryption of files in the cloud. (GPL-3.0-only)
 - [Hdiv](https://github.com/hdiv/hdiv) - Runtime application that repels application security risks included in the OWASP Top 10, including SQL injection, cross-site scripting, cross-site request forgery, data tampering, and brute force attacks.
 - [jjwt](https://github.com/jwtk/jjwt) - JSON web token for Java and Android.


### PR DESCRIPTION
[Certificate ripper](https://github.com/Hakky54/certificate-ripper) extracts server certifcates including the full chain into a der, p7b, pkcs12 or pem file.

Example usage:
```bash
java -jar crip.jar export der -u=https://github.com
```

## Demo
https://user-images.githubusercontent.com/16032204/211771171-d1ed525b-79d4-4943-a75f-249035db9446.mov
