### PR TITLE
add log-capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,7 @@ _Other stuff related to testing._
 - [ConsoleCaptor](https://github.com/Hakky54/console-captor) - Captures console output for unit testing purposes.
 - [junit-dataprovider](https://github.com/TNG/junit-dataprovider) - TestNG-like data provider/runner for JUnit.
 - [LogCaptor](https://github.com/Hakky54/log-captor) - Captures log entries for unit testing purposes.
+- [log-capture](https://github.com/dm-drogeriemarkt/log-capture) - Captures log entries and provides assertions, for unit and integration testing
 - [Mutability Detector](https://github.com/MutabilityDetector/MutabilityDetector) - Reports whether instances of a given class are immutable.
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
 - [TestContainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.


### PR DESCRIPTION
* log-capture asserts actually logged messages (after string interpolation etc.) in contrast to LogCaptor, which means:
  * it only supports logback as a logger
  * it does **not** depend on the logging facade/supports all facades
  * it also works well for integration tests, not only for unit tests
* it also offers more extensive, fluent assertions for log messages, to assert
  * order of logged messages
  * markers
  * logged Exceptions
  * logger name
  * MDC content

Disclaimer: We've been using it extensively for more than three years now, so I'd say it's mature. But I'm also blowing my own trumpet here.
