### PR TITLE
Add Intelligent Java entry to readme machine learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ _Everything that simplifies interactions with the database._
 - [Flyway](https://flywaydb.org) - Simple database migration tool.
 - [H2](https://h2database.com) - Small SQL database notable for its in-memory functionality.
 - [HikariCP](https://github.com/brettwooldridge/HikariCP) - High-performance JDBC connection pool.
-- [HSQLDB](https://hsqldb.org/) - HyperSQL 100% Java database. 
+- [HSQLDB](https://hsqldb.org/) - HyperSQL 100% Java database.
 - [JDBI](http://jdbi.org) - Convenient abstraction of JDBC.
 - [Jedis](https://github.com/xetorthio/jedis) - Small client for interaction with Redis, with methods for commands.
 - [Jest](https://github.com/searchbox-io/Jest) - Client for the Elasticsearch REST API.
@@ -613,6 +613,7 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [Smile](https://github.com/haifengl/smile) - Statistical Machine Intelligence and Learning Engine provides a set of machine learning algorithms and a visualization library.
 - [Tribuo](https://tribuo.org/) - Provides tools for classification, regression, clustering, model development and interfaces with other libraries such as scikit-learn, pytorch and TensorFlow.
 - [Weka](https://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization. (GPL-3.0-only)
+- [Intelligent java](https://github.com/Barqawiz/IntelliJava) - seamlessly integration with remote deep learning frameworks and language models using few java lines..
 
 ### Messaging
 

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [Deeplearning4j](https://deeplearning4j.org) - Distributed and multi-threaded deep learning library.
 - [DJL](https://djl.ai) - High-level and engine-agnostic framework for deep learning.
 - [H2O ![c]](https://www.h2o.ai) - Analytics engine for statistics over big data.
+- [Intelligent java](https://github.com/Barqawiz/IntelliJava) - seamlessly integrates with remote deep learning and language models using few java lines.
 - [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
 - [m2cgen](https://github.com/BayesWitnesses/m2cgen) - CLI tool to transpile models into native code.
 - [oj! Algorithms](https://www.ojalgo.org/) - High-performance mathematics, linear algebra and optimisation needed for data science, machine learning and scientific computing.
@@ -613,7 +614,6 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [Smile](https://github.com/haifengl/smile) - Statistical Machine Intelligence and Learning Engine provides a set of machine learning algorithms and a visualization library.
 - [Tribuo](https://tribuo.org/) - Provides tools for classification, regression, clustering, model development and interfaces with other libraries such as scikit-learn, pytorch and TensorFlow.
 - [Weka](https://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization. (GPL-3.0-only)
-- [Intelligent java](https://github.com/Barqawiz/IntelliJava) - seamlessly integration with remote deep learning frameworks and language models using few java lines..
 
 ### Messaging
 


### PR DESCRIPTION
Add Intelligent Java Github open-source repo to the Machine Learning section, this repo makes it easy to integrate with the latest and greatest frameworks like GPT-3 and Cohere models and publish to maven repos.
Intelligent java library mindset: With the rise of remote AI models, traditional Java is still focusing on the traditional enterprise. Our new open-source library aims to bridge that gap, making it simple to integrate with the latest models.

<!--
Please read the CONTRIBUTING.md first. The most important parts regarding the actual entry:

- Write about it's unique selling point compared to other projects.
- If it's a commercial project, then mark it as such, e.g. `[Title ![c]](URL)`.
- Ensure that you provide concise and informative descriptions.
- Do not use a description like "A library/project/tool/framework for JSON processing in Java" since all of this is implied.
- Finish the description with a dot.
- Try to order it alphabetically.
-->
