### PR TITLE
Add Topaz OSS authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [SSLContext-Kickstart](https://github.com/Hakky54/sslcontext-kickstart) - High-level SSL context builder for configuring HTTP clients with SSL/TLS.
 - [Themis](https://github.com/cossacklabs/themis) - Multi-platform high-level cryptographic library provides easy-to-use encryption for protecting sensitive data: secure messaging with forward secrecy, secure data storage (AES256GCM); suits for building end-to-end encrypted applications.
 - [Tink](https://github.com/google/tink) - Provides a simple and misuse-proof API for common cryptographic tasks.
+- [Topaz](https://www.topaz.sh) - Fine-grained authorization for Java applications, support RBAC, ABAC, and ReBAC. 
 
 ### Serialization
 


### PR DESCRIPTION
Hi. Topaz.sh is the only OSS authorization project that lets your support both OPA policies and the google Zanzibar data-centric model. It might not be widely adopted yet but it is the only system that lets you add support for RBAC, ABAC, and ReBAC from day 1.

<!--
Please read the CONTRIBUTING.md first. The most important parts regarding the actual entry:

- Write about it's unique selling point compared to other projects.
- If it's a commercial project, then mark it as such, e.g. `[Title ![c]](URL)`.
- Ensure that you provide concise and informative descriptions.
- Do not use a description like "A library/project/tool/framework for JSON processing in Java" since all of this is implied.
- Finish the description with a dot.
- Try to order it alphabetically.
-->
