### PR TITLE
Add Java Magician

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ _Sites to read._
 - [Java, SQL, and jOOQ](https://blog.jooq.org)
 - [Java.net](https://community.oracle.com/community/java)
 - [Javalobby](https://dzone.com/java-jdk-development-tutorials-tools-news)
+- [Java Magician](https://javamagician.com/) (Spanish)
 - [JavaWorld](https://www.javaworld.com)
 - [JAXenter](https://jaxenter.com)
 - [RebelLabs](https://zeroturnaround.com/rebellabs)
@@ -1307,7 +1308,6 @@ _Sites to read._
 - [Vanilla Java](https://vanilla-java.github.io)
 - [Voxxed](https://www.voxxed.com)
 - [Java Weekly](https://discu.eu/weekly/java/)
-- [Java Magician](https://javamagician.com/) (Spanish)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,7 @@ _Sites to read._
 - [Vanilla Java](https://vanilla-java.github.io)
 - [Voxxed](https://www.voxxed.com)
 - [Java Weekly](https://discu.eu/weekly/java/)
+- [Java Magician](https://javamagician.com/) (Spanish)
 
 ## Contributing
 


### PR DESCRIPTION
Java Magician is a website that features free courses, tutorials and articles in **Spanish** teaching Java, as well as its libraries and frameworks, aimed at novice/beginner programmers, but also going into detail on some topics for experts. It also features some cool AI generated images of wizards 🧙‍♂️, lightnings 🌩 and coffee cups ☕.