### PR TITLE
Rename Monitoring to Observability/Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ A curated list of awesome Java frameworks, libraries and software.
   - [Microservice](#microservice)
   - [Miscellaneous](#miscellaneous)
   - [Mobile Development](#mobile-development)
-  - [Monitoring](#monitoring)
   - [Native](#native)
   - [Natural Language Processing](#natural-language-processing)
   - [Networking](#networking)
+  - [Observability/Monitoring](#observability/monitoring)
   - [ORM](#orm)
   - [PaaS](#paas)
   - [PDF](#pdf)
@@ -713,32 +713,6 @@ _Tools for creating or managing mobile applications._
 - [MobileUI](https://mobileui.dev) - Cross-platform framework for developing mobile apps with native UI in Java and Kotlin.
 - [Multi-OS Engine](https://multi-os-engine.org) - Open-source, cross-platform engine to develop native mobile (iOS, Android, etc.) apps.
 
-### Observability/Monitoring
-
-_Tools that observe/monitor applications in production._
-
-- [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
-- [Failsafe Actuator](https://github.com/zalando/failsafe-actuator) - Out of the box monitoring of Failsafe Circuit Breaker in Spring-Boot environment.
-- [Glowroot](https://glowroot.org) - Open-source Java APM.
-- [HertzBeat](https://github.com/dromara/hertzbeat) - Real-time monitoring system with custom-monitor and agentless.
-- [inspectIT](https://www.inspectit.rocks) - Captures detailed run-time information via hooks that can be changed on the fly. It supports tracing over multiple systems via the OpenTracing API and can correlate the data with end user monitoring.
-- [Instrumental ![c]](https://instrumentalapp.com) - Real-time Java application performance monitoring. A commercial service with free development accounts.
-- [JavaMelody](https://github.com/javamelody/javamelody) - Performance monitoring and profiling.
-- [Jaeger client](https://github.com/jaegertracing/jaeger-client-java) - Jaeger client.
-- [jmxtrans](https://github.com/jmxtrans/jmxtrans) - Connect to multiple JVMs and query them for their attributes via JMX. Its query language is based on JSON, which allows non-Java programmers to access the JVM attributes. Supports different output writes, including Graphite, Ganglia, and StatsD.
-- [Jolokia](https://jolokia.org) - JMX over REST.
-- [Metrics](https://github.com/dropwizard/metrics) - Expose metrics via JMX or HTTP and send them to a database.
-- [Datadog ![c]](https://github.com/DataDog/dd-trace-java) - Modern monitoring & analytics.
-- [nudge4j](https://github.com/lorenzoongithub/nudge4j) - Remote developer console from the browser for Java 8 via bytecode injection.
-- [Pinpoint](https://github.com/naver/pinpoint) - Open-source APM tool.
-- [Prometheus](https://github.com/prometheus/client_java) - Provides a multi-dimensional data model, DSL, autonomous server nodes and much more.
-- [Sentry ![c]](https://github.com/getsentry/sentry-java) - Integration with [Sentry](https://github.com/getsentry/sentry), an application error tracking and performance analysis platform.
-- [SPM ![c]](https://github.com/sematext/sematext-agent-java) - Performance monitor with distributing transaction tracing for JVM apps.
-- [Stagemonitor](https://github.com/stagemonitor/stagemonitor) - Open-source performance monitoring and transaction tracing for JVM apps.
-- [Sysmon](https://github.com/palantir/Sysmon) - Lightweight platform monitoring tool for Java VMs.
-- [zipkin](https://zipkin.io) - Distributed tracing system which gathers timing data needed to troubleshoot latency problems in microservice architectures.
-- [hippo4j](https://github.com/opengoofy/hippo4j/blob/develop/README-EN.md) - Dynamic and observable thread pool framework.
-
 ### Native
 
 _For working with platform-specific native libraries._
@@ -776,6 +750,32 @@ _Libraries for building network servers._
 - [Undertow](http://undertow.io) - Web server providing both blocking and non-blocking APIs based on NIO. Used as a network layer in WildFly. (LGPL-2.1-only)
 - [urnlib](https://github.com/slub/urnlib) - Represent, parse and encode URNs, as in RFC 2141. (GPL-3.0-only)
 - [Fluency](https://github.com/komamitsu/fluency) - High throughput data ingestion logger to Fluentd and Fluent Bit.
+
+### Observability/Monitoring
+
+_Tools that observe/monitor applications in production by providing telemetry._
+
+- [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
+- [Failsafe Actuator](https://github.com/zalando/failsafe-actuator) - Out of the box monitoring of Failsafe Circuit Breaker in Spring-Boot environment.
+- [Glowroot](https://glowroot.org) - Open-source Java APM.
+- [HertzBeat](https://github.com/dromara/hertzbeat) - Real-time monitoring system with custom-monitor and agentless.
+- [inspectIT](https://www.inspectit.rocks) - Captures detailed run-time information via hooks that can be changed on the fly. It supports tracing over multiple systems via the OpenTracing API and can correlate the data with end user monitoring.
+- [Instrumental ![c]](https://instrumentalapp.com) - Real-time Java application performance monitoring. A commercial service with free development accounts.
+- [JavaMelody](https://github.com/javamelody/javamelody) - Performance monitoring and profiling.
+- [Jaeger client](https://github.com/jaegertracing/jaeger-client-java) - Jaeger client.
+- [jmxtrans](https://github.com/jmxtrans/jmxtrans) - Connect to multiple JVMs and query them for their attributes via JMX. Its query language is based on JSON, which allows non-Java programmers to access the JVM attributes. Supports different output writes, including Graphite, Ganglia, and StatsD.
+- [Jolokia](https://jolokia.org) - JMX over REST.
+- [Metrics](https://github.com/dropwizard/metrics) - Expose metrics via JMX or HTTP and send them to a database.
+- [Datadog ![c]](https://github.com/DataDog/dd-trace-java) - Modern monitoring & analytics.
+- [nudge4j](https://github.com/lorenzoongithub/nudge4j) - Remote developer console from the browser for Java 8 via bytecode injection.
+- [Pinpoint](https://github.com/naver/pinpoint) - Open-source APM tool.
+- [Prometheus](https://github.com/prometheus/client_java) - Provides a multi-dimensional data model, DSL, autonomous server nodes and much more.
+- [Sentry ![c]](https://github.com/getsentry/sentry-java) - Integration with [Sentry](https://github.com/getsentry/sentry), an application error tracking and performance analysis platform.
+- [SPM ![c]](https://github.com/sematext/sematext-agent-java) - Performance monitor with distributing transaction tracing for JVM apps.
+- [Stagemonitor](https://github.com/stagemonitor/stagemonitor) - Open-source performance monitoring and transaction tracing for JVM apps.
+- [Sysmon](https://github.com/palantir/Sysmon) - Lightweight platform monitoring tool for Java VMs.
+- [zipkin](https://zipkin.io) - Distributed tracing system which gathers timing data needed to troubleshoot latency problems in microservice architectures.
+- [hippo4j](https://github.com/opengoofy/hippo4j/blob/develop/README-EN.md) - Dynamic and observable thread pool framework.
 
 ### ORM
 

--- a/README.md
+++ b/README.md
@@ -713,9 +713,9 @@ _Tools for creating or managing mobile applications._
 - [MobileUI](https://mobileui.dev) - Cross-platform framework for developing mobile apps with native UI in Java and Kotlin.
 - [Multi-OS Engine](https://multi-os-engine.org) - Open-source, cross-platform engine to develop native mobile (iOS, Android, etc.) apps.
 
-### Monitoring
+### Observability/Monitoring
 
-_Tools that monitor applications in production._
+_Tools that observe/monitor applications in production._
 
 - [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
 - [Failsafe Actuator](https://github.com/zalando/failsafe-actuator) - Out of the box monitoring of Failsafe Circuit Breaker in Spring-Boot environment.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A curated list of awesome Java frameworks, libraries and software.
   - [Native](#native)
   - [Natural Language Processing](#natural-language-processing)
   - [Networking](#networking)
-  - [Observability/Monitoring](#observability/monitoring)
+  - [Observability/Monitoring](#observabilitymonitoring)
   - [ORM](#orm)
   - [PaaS](#paas)
   - [PDF](#pdf)


### PR DESCRIPTION
Observability is a wider term and there are items under monitoring that are not strictly monitoring tools but they might fit better under the umbrella of Observability.