### PR TITLE
add fury serialization framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ _Libraries that handle serialization with high efficiency._
 
 - [FlatBuffers](https://github.com/google/flatbuffers) - Memory-efficient serialization library that can access serialized data without unpacking and parsing it.
 - [FST](https://github.com/RuedigerMoeller/fast-serialization) - JDK-compatible, high-performance object graph serialization.
-- [Fury](https://github.com/alipay/fury) - Blazing fast object graph serialization framework powered by JIT and zero-copy  .
+- [Fury](https://github.com/alipay/fury) - Blazing fast object graph serialization framework powered by JIT and zero-copy.
 - [Kryo](https://github.com/EsotericSoftware/kryo) - Fast and efficient object graph serialization framework.
 - [MessagePack](https://github.com/msgpack/msgpack-java) - Efficient binary serialization format.
 - [PHP Serializer](https://github.com/marcospassos/java-php-serializer) - Serializing objects in the PHP serialization format.

--- a/README.md
+++ b/README.md
@@ -994,6 +994,7 @@ _Libraries that handle security, authentication, authorization or session manage
 
 _Libraries that handle serialization with high efficiency._
 
+- [Fury](https://github.com/alipay/fury) - Blazing fast object graph serialization framework powered by JIT and zero-copy  .
 - [FlatBuffers](https://github.com/google/flatbuffers) - Memory-efficient serialization library that can access serialized data without unpacking and parsing it.
 - [FST](https://github.com/RuedigerMoeller/fast-serialization) - JDK-compatible, high-performance object graph serialization.
 - [Kryo](https://github.com/EsotericSoftware/kryo) - Fast and efficient object graph serialization framework.

--- a/README.md
+++ b/README.md
@@ -994,9 +994,9 @@ _Libraries that handle security, authentication, authorization or session manage
 
 _Libraries that handle serialization with high efficiency._
 
-- [Fury](https://github.com/alipay/fury) - Blazing fast object graph serialization framework powered by JIT and zero-copy  .
 - [FlatBuffers](https://github.com/google/flatbuffers) - Memory-efficient serialization library that can access serialized data without unpacking and parsing it.
 - [FST](https://github.com/RuedigerMoeller/fast-serialization) - JDK-compatible, high-performance object graph serialization.
+- [Fury](https://github.com/alipay/fury) - Blazing fast object graph serialization framework powered by JIT and zero-copy  .
 - [Kryo](https://github.com/EsotericSoftware/kryo) - Fast and efficient object graph serialization framework.
 - [MessagePack](https://github.com/msgpack/msgpack-java) - Efficient binary serialization format.
 - [PHP Serializer](https://github.com/marcospassos/java-php-serializer) - Serializing objects in the PHP serialization format.


### PR DESCRIPTION
Fury is a multiple-language serialization framework  powered by JIT and zero-copy:
- JIT for speed,  provide a JIT framework to generate serializer code at runtime in an async multi-thread way to speed serialization, providing speed up by:
  - reduce memory access by inline variable in generated code.
  - reduce virtual method invocation by inline call in generated code.
  - reduce conditional branching.
  - reduce hash lookup.
- Zero-copy: cross-language out-of-band serialization inspired by [pickle5](https://peps.python.org/pep-0574/) and off-heap read/write.
- Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian without modifying any code, but faster, which can greatly improve the efficiency of  RPC calls, data transfer and object persistence.
- JDK serialization 100% compatible: JDK `writeObject/readObject/writeReplace/readResolve/readObjectNoData/Externalizable ` serialization API supported, JDK8~21 supported, JDK 17+ record supported.


At this writing, it's the fast java serialization framework  in https://github.com/eishay/jvm-serializers/wiki
![image](https://github.com/akullpp/awesome-java/assets/12445254/33a96dd1-3936-4d36-b67e-e8395783812d)
![image](https://github.com/akullpp/awesome-java/assets/12445254/0eabc6f0-1822-417e-bb1f-4a1a3f54cdf1)

For JDK 17+ record, fury is 5~7x faster than kryo:
![image](https://github.com/akullpp/awesome-java/assets/12445254/35e55136-f0eb-4fd8-a5fb-4f6c365dd8df)

