### PR TITLE
Add (GUI) SnapKit and (IDE) SnapCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ _Libraries to create modern graphical user interfaces._
 
 - [JavaFX](https://wiki.openjdk.java.net/display/OpenJFX/Main) - Successor of Swing.
 - [Scene Builder](https://gluonhq.com/products/scene-builder/) - Visual layout tool for JavaFX applications.
+- [SnapKit](https://github.com/reportmill/SnapKit) - Modern Java UI library for both desktop and web.
 - [SWT](https://www.eclipse.org/swt/) - Graphical widget toolkit.
 
 ### High Performance
@@ -523,6 +524,7 @@ _Integrated development environments that try to simplify several aspects of dev
 - [IntelliJ IDEA ![c]](https://www.jetbrains.com/idea/) - Supports many JVM languages and provides good options for Android development. The commercial edition targets the enterprise sector.
 - [jGRASP](https://www.jgrasp.org) - Created to provide software visualizations that work in conjunction with the debugger such as Control Structure Diagrams, UML class diagrams and Object Viewer.
 - [NetBeans](https://netbeans.apache.org) - Provides integration for several Java SE and EE features, from database access to HTML5.
+- [SnapCode](https://reportmill.com/SnapCode/) - Modern IDE for Java running in the browser, focused on education.
 - [Visual Studio Code](https://code.visualstudio.com/docs/languages/java) - Provides Java support for lightweight projects with a simple, modern workflow by using extensions from the internal marketplace.
 
 ### Imagery


### PR DESCRIPTION
Please add these two modern Java Client technologies. Adoption rate is low, but they are both compelling entries in categories that have few options, and both have undergone considerable recent development activity.

SnapKit: This is the first real new entry in the Java GUI space in years. It is the first Java UI library that is designed to run either on the desktop or in the browser. It has a complete set of components (list, table, tree, rich text, etc.) and has modern features such as integrated graphics, animation, and image effects. It allows apps to run natively in the browser (using DOM and Canvas) and natively on the desktop (using Java2D/AWT/Swing). It covers the middle ground between Swing (a little out of date) and JavaFX (a little ahead of its time).

SnapCode: This full Java IDE is the first real new entry in the Java IDE space in years and runs in the browser. It makes Java immediately accessible without cumbersome download/install and makes coding simple by supporting snippets and puzzle block coding. And it makes coding fun and relevant by supporting graphics, 3D and charting.
