### PR TITLE
Adding awesome-hybris repo link to the Awesome section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ _Awesome Lists related to the Java & JVM ecosystem._
 - [Awesome Microservices](https://github.com/mfornos/awesome-microservices)
 - [Awesome REST](https://github.com/marmelab/awesome-rest)
 - [Awesome Selenium](https://github.com/christian-bromann/awesome-selenium)
+- [Awesome Hybris](https://github.com/eminyagiz42/awesome-hybris)
 - [ciandcd](https://github.com/ciandcd/awesome-ciandcd)
 - [Useful Java Links](https://github.com/Vedenin/useful-java-links)
 - [Java Concurrency Checklist](https://github.com/code-review-checklists/java-concurrency)


### PR DESCRIPTION
I've created a dedicated awesome list about hybris. As that is a part of Java community and commonly used Java technologies such as Spring MVC, Apache Ant, Solr and Groovy platform. I thought it could be worth being linked from here.