### PR TITLE
Add selfie snapshot testing to `Testing -> Miscellaneous`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,7 @@ _Other stuff related to testing._
 - [log-capture](https://github.com/dm-drogeriemarkt/log-capture) - Captures log entries and provides assertions for unit and integration testing.
 - [Mutability Detector](https://github.com/MutabilityDetector/MutabilityDetector) - Reports whether instances of a given class are immutable.
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
+- [Selfie](https://github.com/diffplug/selfie) - Snapshot testing (inline and on disk).
 - [TestContainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 - [pojo-tester](https://www.pojo.pl) - Automatically performs tests on basic POJO methods. (LGPL-3.0-only)
 


### PR DESCRIPTION
Added the [selfie](https://github.com/diffplug/selfie) snapshot testing library under `Testing -> Miscellaneous`.

I debated adding it under `Testing -> Matchers`, but `Miscellaneous` felt like a better fit. Happy to recategorize if you prefer.