### PR TITLE
add native-lib-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ _For working with platform-specific native libraries._
 - [JavaCPP](https://github.com/bytedeco/javacpp) - Provides efficient and easy access to native C++.
 - [JNA](https://github.com/java-native-access/jna) - Work with native libraries without writing JNI. Also provides interfaces to common system libraries.
 - [JNR](https://github.com/jnr/jnr-ffi) - Work with native libraries without writing JNI. Also provides interfaces to common system libraries. Same goals as JNA, but faster, and serves as the basis for the upcoming [Project Panama](http://openjdk.java.net/projects/panama).
+- [native-lib-loader](https://github.com/scijava/native-lib-loader) - Native library loader for extracting and loading native libraries from Java. 
 
 ### Natural Language Processing
 


### PR DESCRIPTION
The native library loader is a utility that assists with loading native libraries from Java. It provides the ability to painlessly identify, extract and load the correct platform-specific native library from a JAR file.