### PR TITLE
Fix wrong casing in "Testcontainers" entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1122,7 +1122,7 @@ _Other stuff related to testing._
 - [pojo-tester](https://www.pojo.pl) - Automatically performs tests on basic POJO methods. (LGPL-3.0-only)
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
 - [Selfie](https://github.com/diffplug/selfie) - Snapshot testing (inline and on disk).
-- [TestContainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+- [Testcontainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 
 #### Mocking
 


### PR DESCRIPTION
The Testcontainers entry used a wrong camel-casing for the name.

Disclaimer: I am one of the maintainers of the Testcontainers project ;) 