### PR TITLE
Add vips-ffm to Imagery section

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ _Libraries that assist with the creation, evaluation or manipulation of graphica
 - [TwelveMonkeys](https://github.com/haraldk/TwelveMonkeys) - Collection of plugins that extend the number of supported image file formats.
 - [ZXing](https://github.com/zxing/zxing) - Multi-format 1D/2D barcode image processing library.
 - [image-comparison](https://github.com/romankh3/image-comparison) - Library that compares 2 images with the same sizes and shows the differences visually by drawing rectangles. Some parts of the image can be excluded from the comparison.
+- [vips-ffm](https://github.com/lopcode/vips-ffm) - Comprehensive bindings for libvips, using Java's "Foreign Function & Memory" API.
 
 ### Introspection
 


### PR DESCRIPTION
Adds [vips-ffm](https://github.com/lopcode/vips-ffm) to the Imagery section.

My reasons for adding:
* There are no other libraries listed that use [libvips](https://github.com/libvips/libvips), which is quite popular for image processing
* It's a novel usage of JDK 22's Foreign Function & Memory (FFM) API
* Performance for image processing is significantly better than existing options
* There are already some quite large users of the library

I didn't make `libvips` a link in the entry, as if you're looking at imagery options libvips is probably known to you, and I couldn't see any other examples of linking out in descriptions.

I created the library, but still feel it meets the requirements noted in CONTRIBUTING - of course feel free to view critically.

<!--
Please read the CONTRIBUTING.md first. The most important parts regarding the actual entry:

- Write about it's unique selling point compared to other projects.
- If it's a commercial project, then mark it as such, e.g. `[Title ![c]](URL)`.
- Ensure that you provide concise and informative descriptions.
- Do not use a description like "A library/project/tool/framework for JSON processing in Java" since all of this is implied.
- Finish the description with a dot.
- Try to order it alphabetically.
-->
