### PR TITLE
Add Apitally to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ _Tools for creating or managing mobile applications._
 
 _Tools that observe/monitor applications in production by providing telemetry._
 
+- [Apitally](https://github.com/apitally/apitally-java) - Simple, privacy-focused API monitoring, analytics and request logging for Spring Boot apps.
 - [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
 - [Datadog ![c]](https://github.com/DataDog/dd-trace-java) - Modern monitoring & analytics.
 - [Dropwizard Metrics](https://github.com/dropwizard/metrics) - Expose metrics via JMX or HTTP and send them to a database.


### PR DESCRIPTION
Apitally is a simple, privacy-focused API monitoring, analytics and request logging tool. It has an open-source Java SDK for Spring Boot apps.

GitHub: https://github.com/apitally/apitally-java
Docs: https://docs.apitally.io
Website: https://apitally.io