### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ _Libraries that specialize in processing text._
 - [CogCompNLP](https://github.com/CogComp/cogcomp-nlp) - Provides common annotators for plain text input. (Research and Academic Use License)
 - [CoreNLP](https://nlp.stanford.edu/software/corenlp.shtml) - Provides a set of fundamental tools for tasks like tagging, named entity recognition, and sentiment analysis. (GPL-3.0-or-later)
 - [DKPro](https://dkpro.github.io) - Collection of reusable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
+- [Hypherator](https://github.com/ejossev/hypherator-java) - Java hyphenation library with iterator-like interface. Can be used out-of-the box - dictionaries for multiple languages are bundled in. 
 - [LingPipe](http://alias-i.com/lingpipe/) - Toolkit for tasks ranging from POS tagging to sentiment analysis.
 
 ### Networking


### PR DESCRIPTION
added the library Hypherator under NLP section

--> out-of-the box support for broad collection of languages (bundles LibreOffice dictionaries with compatible licenses)
--> no JNA, pure Java based reimplementation of Hunspell's Hyphen project
--> compatible with Hunspell (and thus with OO, LO, Mozilla, ...)

