### PR TITLE
Add Javadoc-publisher to Awesome Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ _Libraries which provide general utility functions._
 - [Gephi](https://github.com/gephi/gephi) - Cross-platform for visualizing and manipulating large graph networks. (GPL-3.0-only)
 - [Guava](https://github.com/google/guava) - Collections, caching, primitives support, concurrency libraries, common annotations, string processing, I/O, and more.
 - [JADE](https://jade.tilab.com) - Framework and environment for building and debugging multi-agent systems. (LGPL-2.0-only)
+- [Javadoc Publisher](https://github.com/MathieuSoysal/Javadoc-publisher.yml) - Generate Javadoc from your maven/gradle project and deploy it automatically on GitHub Page.
 - [Java Diff Utils](https://java-diff-utils.github.io/java-diff-utils/) - Utilities for text or data comparison and patching.
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.


### PR DESCRIPTION
[Javadoc-publisher](https://github.com/MathieuSoysal/Javadoc-publisher.yml) - Generate Javadoc from your Maven or Gradle project and deploy it automatically with GitHub Pages. Unique in supporting both build systems and automating documentation hosting.

This project is developer-friendly (MIT license, English docs), has 50+ stars, and fills a gap for easy Javadoc publishing and hosting. If it doesn’t fully meet (a)-(c), I believe its unique combination of features justifies inclusion.

Thank you for considering!