### PR TITLE
Adding simple-openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ _Frameworks that help you to leverage LLMs and AI._
 
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) -  Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
+- [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.
 - [Spring AI](https://spring.io/projects/spring-ai) - Application framework for AI engineering for Spring.
 
 ### Bean Mapping


### PR DESCRIPTION
OpenAI recognizes [simple-openai](https://github.com/sashirestela/simple-openai) as a [Java community library](https://platform.openai.com/docs/libraries#java).