### PR TITLE
Fix JBang link

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ _Everything else._
 - [ISBN core](https://github.com/ladutsko/isbn-core) - A small library that contains a representation object of ISBN-10 and ISBN-13 and tools to parse, validate and format one.
 - [J2ObjC](https://github.com/google/j2objc) - Java-to-Objective-C translator for porting Android libraries to iOS.
 - [JBake](https://jbake.org) - Static website generator.
+- [JBang](https://www.jbang.dev/) - JBang makes it easy to use Java for scripting. It lets you use a single file for code and dependency management and allows you to run it directly.
 - [JBot](https://github.com/rampatra/jbot) - Framework for building chatbots. (GPL-3.0-only)
 - [JCuda](http://jcuda.org) - JCuda offers Java bindings for CUDA and CUDA-related libraries.
 - [JEmoji](https://github.com/felldo/JEmoji) - An auto-generated emoji library that provides type-safe direct access to emojis and alias support for Discord, Slack, GitHub and many more features.
@@ -753,8 +754,6 @@ _Everything else._
 - [webcam-capture](https://github.com/sarxos/webcam-capture) - Library for using built-in and external webcams directly in Java.
 - [XMLBeam](https://github.com/SvenEwald/xmlbeam) - Processes XML by using annotations or XPath within code.
 - [yGuard](https://github.com/yWorks/yGuard) - Obfuscation via renaming and shrinking.
-- [JBang](https://www.jbang.dev/) - JBang makes it easy to use Java for scripting. It lets you use a single file for
-  code and dependency management and allows you to run it directly.
 
 ### Mobile Development
 


### PR DESCRIPTION
Instead of pointing to a fork of JBang, the maintained homepage should be used.

Also sort-in alphabetically.
