### PR TITLE
Add BitDive to Testing > Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,7 @@ _Provide environments to run tests for a specific use case._
 - [Apache JMeter](http://jmeter.apache.org) - Functional testing and performance measurements.
 - [JMeter DSL.java](https://abstracta.github.io/jmeter-java-dsl/) - Load tests with JMeter as simple as a JUnit test.
 - [Arquillian](http://arquillian.org) - Integration and functional testing platform for Java EE containers.
+- [BitDive ![c]](https://bitdive.io) - Zero-code integration testing platform that generates tests from runtime application behavior.
 - [cdi-test](https://github.com/guhilling/cdi-test) - JUnit extension for easy and efficient testing of CDI components.
 - [Citrus](https://citrusframework.org) - Integration testing framework that focuses on both client- and server-side messaging.
 - [Gatling](https://gatling.io) - Load testing tool designed for ease of use, maintainability and high performance.


### PR DESCRIPTION
Added BitDive to the Testing > Frameworks section.

**Unique selling point:**
Automatically generates integration tests by capturing runtime application behavior - no test code required. Unlike traditional testing frameworks that require manual test writing, BitDive observes actual method executions, HTTP calls, and database queries to create realistic tests.

**Commercial:** Yes, with free tier available. Clear pricing at https://bitdive.io/pricing

**Documentation:** https://bitdive.io/docs/getting-started/