### PR TITLE
Add boot-usage-spring-boot-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ _Tools that observe/monitor applications in production by providing telemetry._
 
 - [Apitally](https://github.com/apitally/apitally-java) - Simple, privacy-focused API monitoring, analytics and request logging for Spring Boot apps.
 - [Automon](https://github.com/stevensouza/automon) - Combines the power of AOP with monitoring and/or logging tools.
-- [boot-usage-spring-boot-starter](https://github.com/dhruv-15-03/boot-usage) - Spring Boot Actuator extension providing application startup and runtime metrics including JVM uptime, memory usage, and CPU load.
+- [Boot Usage Spring Boot Starter](https://github.com/dhruv-15-03/boot-usage) - Spring Boot Actuator extension providing application startup and runtime metrics including JVM uptime, memory usage, and CPU load.
 - [Datadog ![c]](https://github.com/DataDog/dd-trace-java) - Modern monitoring & analytics.
 - [Dropwizard Metrics](https://github.com/dropwizard/metrics) - Expose metrics via JMX or HTTP and send them to a database.
 - [Failsafe Actuator](https://github.com/zalando/failsafe-actuator) - Out of the box monitoring of Failsafe Circuit Breaker in Spring-Boot environment.


### PR DESCRIPTION
## Description

Adding [boot-usage-spring-boot-starter](https://github.com/dhruv-15-03/boot-usage) to the Monitoring section.

**What it does:**
- Provides a Spring Boot Actuator endpoint (`/actuator/bootusage`) that exposes application startup and runtime metrics
- Includes JVM uptime, heap/non-heap memory usage percentages, thread count, CPU load, and system load average
- Auto-configures with Spring Boot 3.x

**Why it's noteworthy:**
- Fills a gap in standard Spring Boot Actuator by providing boot-time metrics in a single, easy-to-consume endpoint
- Zero configuration required - just add the dependency
- Lightweight with no external dependencies beyond Spring Boot

**License:** Apache License 2.0

**Documentation:** Available in English at https://github.com/dhruv-15-03/boot-usage#readme