### PR TITLE
Update json-io description to include TOON format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ _Libraries for serializing and deserializing JSON to and from Java objects._
 - [jackson-modules-java8](https://github.com/FasterXML/jackson-modules-java8) - Set of Jackson modules for Java 8 datatypes and features.
 - [Jackson-datatype-money](https://github.com/zalando/jackson-datatype-money) - Open-source Jackson module to support JSON serialization and deserialization of JavaMoney data types.
 - [Jackson](https://github.com/FasterXML/jackson) - Similar to GSON, but offers performance gains if you need to instantiate the library more often.
-- [JSON-io](https://github.com/jdereg/json-io) - Convert Java to JSON. Convert JSON to Java. Pretty print JSON. Java JSON serializer.
+- [JSON-io](https://github.com/jdereg/json-io) - Convert Java to JSON/TOON and back. Supports complex object graphs, cyclic references, and TOON format for 40-50% LLM token savings.
 - [jsoniter](http://jsoniter.com) - Fast and flexible library with iterator and lazy parsing API.
 - [LoganSquare](https://github.com/bluelinelabs/LoganSquare) - JSON parsing and serializing library based on Jackson's streaming API. Outperforms GSON & Jackson's library.
 - [Moshi](https://github.com/square/moshi) - Modern JSON library, less opinionated and uses built-in types like List and Map.


### PR DESCRIPTION
json-io recently added full TOON (Token-Oriented Object Notation) read/write support in v4.85.0.

TOON is a compact format designed for LLM token efficiency (~40-50% fewer tokens than JSON), which is increasingly relevant as Java developers integrate with AI services.

Updated the description to reflect this new capability while keeping it concise.

**Change:**
- Old: `Convert Java to JSON. Convert JSON to Java. Pretty print JSON. Java JSON serializer.`
- New: `Convert Java to JSON/TOON and back. Supports complex object graphs, cyclic references, and TOON format for 40-50% LLM token savings.`