### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for git operations
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "25"


### PR DESCRIPTION
- [x] PR title: "Updating GitHub Action Versions for Better Compatibility"  
- [x] Description: This PR updates outdated GitHub Action versions to ensure compatibility and security. Specifically, it upgrades `actions/checkout` from `v4` to `v6` and `actions/setup-java` from `v4` to `v5`. These updates align with the latest best practices and ensure consistent behavior across workflows. The changes will be tested in the CI pipeline of the pull request.