### PR TITLE
Add Spring Boot Swagger MCP to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ _Frameworks that help you to leverage LLMs and AI._
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
 - [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.
 - [Spring AI](https://spring.io/projects/spring-ai) - Application framework for AI engineering for Spring.
+- [Spring Boot Swagger MCP](https://github.com/Neo1228/spring-boot-starter-swagger-mcp) - Automatically turn any Spring Boot application into an MCP server by reusing existing Swagger/OpenAPI documentation.
 
 ### Bean Mapping
 


### PR DESCRIPTION
Added Spring Boot Swagger MCP to the Artificial Intelligence section. This starter allows developers to automatically expose their Spring Boot application's OpenAPI endpoints as MCP tools, making them easily accessible to AI agents.