### PR TITLE
Add Sheetz — one-line Excel/CSV processing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ _Libraries that assist with processing office document formats._
 - [documents4j](https://documents4j.com/#/) - API for document format conversion using third-party converters such as MS Word.
 - [docx4j](https://www.docx4java.org/trac/docx4j) - Create and manipulate Microsoft Open XML files.
 - [fastexcel](https://github.com/dhatim/fastexcel) - High performance library to read and write large Excel (XLSX) worksheets.
+- [Sheetz](https://github.com/chitralabs/sheetz) - Read and write Excel and CSV files with one line of code. Annotation-based mapping, streaming for million-row files, built-in validation.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
 
 ### Financial

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ _Libraries that assist with processing office document formats._
 - [documents4j](https://documents4j.com/#/) - API for document format conversion using third-party converters such as MS Word.
 - [docx4j](https://www.docx4java.org/trac/docx4j) - Create and manipulate Microsoft Open XML files.
 - [fastexcel](https://github.com/dhatim/fastexcel) - High performance library to read and write large Excel (XLSX) worksheets.
-- [Sheetz](https://github.com/chitralabs/sheetz) - Read and write Excel and CSV files with one line of code. Annotation-based mapping, streaming for million-row files, built-in validation.
+- [Sheetz](https://github.com/chitralabs/sheetz) - Library for reading and writing Excel and CSV files with annotation-based mapping, streaming support, and built-in validation.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
 
 ### Financial


### PR DESCRIPTION
## Summary

Adds [Sheetz](https://github.com/chitralabs/sheetz) to the **Document Processing** section.

Sheetz is a Java library that simplifies reading and writing Excel (.xlsx, .xls) and CSV files with a one-line, annotation-based API — replacing 25+ lines of Apache POI boilerplate.

**Key features:**
- One-line read/write: `Sheetz.read("file.xlsx", Product.class)`
- `@Column` annotation mapping with custom headers, required fields, defaults, formats
- Streaming for million-row files with constant ~10MB memory
- Built-in data validation with row-level error reports
- 19 type converters (LocalDate, BigDecimal, UUID, Enum, etc.)
- XLSX, XLS, and CSV with auto-detection
- Spring Boot starter available
- Thread-safe, Java 11+

**Links:**
- GitHub: https://github.com/chitralabs/sheetz
- Maven Central: [io.github.chitralabs.sheetz:sheetz-core](https://central.sonatype.com/artifact/io.github.chitralabs.sheetz/sheetz-core)
- Benchmarks: https://github.com/chitralabs/sheetz-benchmarks
- License: Apache 2.0