### PR TITLE
Add Delta Coverage to Code Coverage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ _Frameworks and tools that enable code coverage metrics collection for test suit
 
 - [Clover](https://www.atlassian.com/software/clover) - Relies on source-code instrumentation instead of bytecode instrumentation.
 - [Cobertura](https://cobertura.github.io/cobertura/) - Relies on offline (or static) bytecode instrumentation and class loading to collect code coverage metrics. (GPL-2.0-only)
+- [Delta Coverage](https://github.com/gw-kit/delta-coverage-plugin) - Computes code coverage of new and modified code based on a provided diff, supporting JaCoCo and IntelliJ coverage engines.
 - [JaCoCo](https://www.eclemma.org/jacoco/) - Framework that enables collection of code coverage metrics, using both offline and runtime bytecode instrumentation.
 
 ### Code Generators


### PR DESCRIPTION
## What is Delta Coverage?

[Delta Coverage](https://github.com/gw-kit/delta-coverage-plugin) is a Gradle plugin and CLI tool that computes code coverage of new and modified code based on a provided diff. It supports JaCoCo and IntelliJ coverage engines.

## Why it belongs here

This submission meets criterion **(d) fills a gap**: none of the existing Code Coverage entries focus on **diff-based coverage** — measuring coverage specifically for changed code. The existing tools (Clover, Cobertura, JaCoCo) measure overall project coverage, while Delta Coverage targets only new/modified lines.

Key differentiators:
- Diff-based: analyzes coverage of changed code only (from git diff, file, or URL)
- Works with both JaCoCo and IntelliJ coverage engines
- Available as Gradle plugin and standalone CLI
- Generates HTML, XML, console, and markdown reports for changed code
- Enforces coverage thresholds on new lines

Licensed under **MIT**. English documentation available.

*Disclosure: I am the author of this project.*