### PR TITLE
Add JVM Hotpath - line-level execution frequency analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [JITWatch](https://github.com/AdoptOpenJDK/jitwatch) - Analyze the JIT compiler optimisations made by the HotSpot JVM.
 - [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM. (GPL-2.0 only WITH Classpath-exception-2.0)
 - [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.
+- [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis. Tracks how many times each line executes to find algorithmic issues.
 
 ### Platform
 

--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [JITWatch](https://github.com/AdoptOpenJDK/jitwatch) - Analyze the JIT compiler optimisations made by the HotSpot JVM.
 - [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM. (GPL-2.0 only WITH Classpath-exception-2.0)
 - [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.
-- [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis. Tracks how many times each line executes to find algorithmic issues.
+- [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis to identify algorithmic bottlenecks.
 
 ### Platform
 


### PR DESCRIPTION
Adds JVM Hotpath to the Performance analysis section.

JVM Hotpath is a Java agent for line-level execution frequency analysis. It tracks how many times each line executes to find algorithmic issues and logic errors - different from traditional profilers which focus on CPU time.