### PR TITLE
Add ArcadeDB to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ _Everything that simplifies interactions with the database._
 - [Apache Drill](https://drill.apache.org) - Distributed, schema on-the-fly, ANSI SQL query engine for Big Data exploration.
 - [Apache Phoenix](https://phoenix.apache.org) - High-performance relational database layer over HBase for low-latency applications.
 - [ArangoDB](https://github.com/arangodb/arangodb-java-driver) - ArangoDB Java driver.
+- [ArcadeDB](https://arcadedb.com) - Multi-model database supporting graphs, documents, key-value, time series and vector embeddings with SQL, Cypher, Gremlin, MongoDB and Redis API compatibility.
 - [Chronicle Map](https://github.com/OpenHFT/Chronicle-Map) - Efficient, in-memory (opt. persisted to disk), off-heap key-value store.
 - [Debezium](https://debezium.io/) - Low latency data streaming platform for change data capture.
 - [druid](https://druid.apache.org) - High-performance, column-oriented, distributed data store.


### PR DESCRIPTION
ArcadeDB is an open-source (Apache 2.0) multi-model database written in Java 21. It supports SQL, Cypher (OpenCypher), Gremlin, GraphQL, and MongoDB query languages, plus Neo4j Bolt, PostgreSQL, MongoDB, and Redis wire protocols. It can run embedded or client-server.
