### PR TITLE
Add java-util to Utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1233,6 +1233,7 @@ _Libraries which provide general utility functions._
 - [JADE](https://jade.tilab.com) - Framework and environment for building and debugging multi-agent systems. (LGPL-2.0-only)
 - [Javadoc Publisher](https://github.com/MathieuSoysal/Javadoc-publisher.yml) - Generate Javadoc from your maven/gradle project and deploy it automatically on GitHub Page.
 - [Java Diff Utils](https://java-diff-utils.github.io/java-diff-utils/) - Utilities for text or data comparison and patching.
+- [java-util](https://github.com/jdereg/java-util) - Zero-dependency collection of high-performance utilities including CompactMap, ConcurrentList, MultiKeyMap, TTLCache, deep object graph operations, and a universal type Converter.
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.
 - [JKScope](https://github.com/evpl/jkscope) - Java scope functions inspired by Kotlin.

--- a/README.md
+++ b/README.md
@@ -1233,7 +1233,7 @@ _Libraries which provide general utility functions._
 - [JADE](https://jade.tilab.com) - Framework and environment for building and debugging multi-agent systems. (LGPL-2.0-only)
 - [Javadoc Publisher](https://github.com/MathieuSoysal/Javadoc-publisher.yml) - Generate Javadoc from your maven/gradle project and deploy it automatically on GitHub Page.
 - [Java Diff Utils](https://java-diff-utils.github.io/java-diff-utils/) - Utilities for text or data comparison and patching.
-- [java-util](https://github.com/jdereg/java-util) - Zero-dependency collection of high-performance utilities including CompactMap, ConcurrentList, MultiKeyMap, TTLCache, deep object graph operations, and a universal type Converter.
+- [java-util](https://github.com/jdereg/java-util) - Zero-dependency, high-performance utilities featuring Converter (universal type conversion), DeepEquals, CaseInsensitiveMap, LRUCache, TTLCache, CompactMap, and object graph traversal.
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.
 - [JKScope](https://github.com/evpl/jkscope) - Java scope functions inspired by Kotlin.

--- a/README.md
+++ b/README.md
@@ -1233,7 +1233,7 @@ _Libraries which provide general utility functions._
 - [JADE](https://jade.tilab.com) - Framework and environment for building and debugging multi-agent systems. (LGPL-2.0-only)
 - [Javadoc Publisher](https://github.com/MathieuSoysal/Javadoc-publisher.yml) - Generate Javadoc from your maven/gradle project and deploy it automatically on GitHub Page.
 - [Java Diff Utils](https://java-diff-utils.github.io/java-diff-utils/) - Utilities for text or data comparison and patching.
-- [java-util](https://github.com/jdereg/java-util) - Zero-dependency, high-performance utilities featuring Converter (universal type conversion), DeepEquals, CaseInsensitiveMap, LRUCache, TTLCache, CompactMap, and object graph traversal.
+- [java-util](https://github.com/jdereg/java-util) - Zero-dependency, high-performance utilities featuring Converter (universal type conversion), DeepEquals, CaseInsensitiveMap, TTLCache, CompactMap, MultiKeyMap, and object graph traversal.
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.
 - [JKScope](https://github.com/evpl/jkscope) - Java scope functions inspired by Kotlin.


### PR DESCRIPTION
[java-util](https://github.com/jdereg/java-util) is a zero-dependency collection of high-performance Java utilities that has been available on Maven Central since 2014.

**What distinguishes it from other entries in Utility:**

- **Zero runtime dependencies** — the single ~700K JAR works from JDK 8 through JDK 24
- **Converter** — universal type conversion across 750+ type pairs with a single `convert(source, TargetType.class)` API, filling a gap the JDK has never addressed
- **DeepEquals** — recursive object graph comparison handling cycles, collections, maps, and arrays — something `Arrays.deepEquals()` cannot do for arbitrary objects
- **CaseInsensitiveMap** — O(1) case-insensitive key lookup (the JDK TreeMap workaround is O(log n)), with thread-safe variants
- **TTLCache** — lightweight, thread-safe caching with time-based expiration and optional LRU eviction, without pulling in a full caching framework
- **CompactMap** — self-optimizing storage that switches internal representation based on size, reducing memory for millions of small maps
- **MultiKeyMap** — N-dimensional composite-key mapping with typed array support for complex lookup scenarios
- **Object graph traversal** — Traverser for walking arbitrary object graphs with visitor pattern and cycle detection

It is Apache 2.0 licensed, actively maintained, and has been used in production for over 10 years.
