### PR TITLE
Add ASTRAL to Science section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ _Frameworks specifically for creating RESTful services._
 
 _Libraries for scientific computing, analysis and visualization._
 
+- [ASTRAL](https://github.com/smirarab/ASTRAL) - Estimates the species tree from a set of unrooted gene trees under the multi-species coalescent model using a quartet-based approach.
 - [BioJava](https://biojava.org/) - Facilitates processing biological data by providing algorithms, file format parsers, sequencing and 3D visualization commonly used in bioinformatics.
 - [Chart-FX](https://github.com/GSI-CS-CO/chart-fx) - Scientific charting library with focus on performance optimised real-time data visualisation at 25 Hz update rates for large data sets.
 - [DataMelt](https://datamelt.org/) - Environment for scientific computation, data analysis and data visualization. (GPL-3.0-or-later)


### PR DESCRIPTION
## Add ASTRAL — species tree estimation from gene trees

[ASTRAL](https://github.com/smirarab/ASTRAL) (Accurate Species TRee ALgorithm) is a widely-used Java tool in computational biology for estimating species trees from sets of gene trees under the multi-species coalescent model. It works by finding the species tree that maximises the number of shared quartet topologies with the input gene trees.

**Why it belongs here:**
- Written entirely in Java (99.6%)
- 273 GitHub stars, actively maintained (updated February 2026)
- Apache-2.0 licence
- Unique in its approach: quartet-based coalescent species tree inference — no other Java tool in the Science section covers phylogenomics
- Comprehensive English documentation including a tutorial, developer guide, and peer-reviewed publications
- Widely cited across ecology and evolutionary biology research

The entry follows the existing format and is sorted alphabetically (before BioJava).