### PR TITLE
Add Dimension-DI to Dependency Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ _Libraries that help to realize the [Inversion of Control](https://en.wikipedia.
 - [Apache DeltaSpike](https://deltaspike.apache.org) - CDI extension framework.
 - [Avaje Inject](https://avaje.io/inject/) - Microservice-focused compile-time injection framework without reflection.
 - [Dagger](https://dagger.dev/) - Compile-time injection framework without reflection.
+- [Dimension-DI](https://github.com/akardapolov/dimension-di) - JSR-330 runtime dependency injection using the JDK Class-File API.
 - [Feather](https://github.com/zsoltherpai/feather) - Ultra-lightweight, JSR-330-compliant dependency injection library.
 - [Governator](https://github.com/Netflix/governator) - Extensions and utilities that enhance Google Guice.
 - [Guice](https://github.com/google/guice) - Lightweight and opinionated framework that completes Dagger.


### PR DESCRIPTION
Dimension-DI occupies a unique niche among existing DI entries. Unlike compile-time frameworks (Dagger, Avaje Inject), it operates at runtime with automatic classpath scanning. Unlike heavier runtime frameworks (Guice, HK2), it avoids proxies, reflection, and bytecode generation entirely by leveraging the JDK Class-File API. This combination is unique among the listed libraries.

This project is developer-friendly (Apache-2.0 license, English documentation) and fills a gap for developers needing a minimal, zero-boilerplate runtime DI container without the overhead of larger frameworks. If it doesn't fully meet criteria (a)-(c), I believe its unique approach and function justifies inclusion under criterion (d).

Thank you for considering!