### PR TITLE
Add input4j to game development frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ _Libraries that facilitate functional programming._
 _Frameworks that support the development of games._
 
 - [FXGL](https://almasb.github.io/FXGL/) - JavaFX Game Development Framework.
-- [input4j](https://gurkenlabs.github.io/input4j/) - Lightweight, cross-platform Java library for gamepad and joystick input handling
+- [input4j](https://gurkenlabs.github.io/input4j/) - Lightweight, cross-platform library for gamepad and joystick input handling.
 - [JBox2D](http://www.jbox2d.org/) - Port of the renowned C++ 2D physics engine.
 - [jMonkeyEngine](https://jmonkeyengine.org) - Game engine for modern 3D development.
 - [libGDX](https://libgdx.com) - All-round cross-platform, high-level framework.

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ _Libraries that facilitate functional programming._
 _Frameworks that support the development of games._
 
 - [FXGL](https://almasb.github.io/FXGL/) - JavaFX Game Development Framework.
+- [input4j](https://gurkenlabs.github.io/input4j/) - Lightweight, cross-platform Java library for gamepad and joystick input handling
 - [JBox2D](http://www.jbox2d.org/) - Port of the renowned C++ 2D physics engine.
 - [jMonkeyEngine](https://jmonkeyengine.org) - Game engine for modern 3D development.
 - [libGDX](https://libgdx.com) - All-round cross-platform, high-level framework.


### PR DESCRIPTION
Cross-platform Java gamepad & joystick library using FFM API
Lightweight, cross-platform Java library for unified gamepad and joystick input handling. Uses Java 22+ Foreign Function & Memory API for native system calls without JNI, supporting Windows (XInput/DirectInput), Linux (evdev), and macOS (IOKit) with zero native dependencies.