### PR TITLE
Add Heap Seance to Performance analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [fastThread ![c]](https://fastthread.io) - Analyze and visualize thread dumps with a free cloud-based upload interface.
 - [GCeasy ![c]](https://gceasy.io) - Tool to analyze and visualize GC logs. It provides a free cloud-based upload interface.
 - [honest-profiler](https://github.com/jvm-profiling-tools/honest-profiler) - Low-overhead, bias-free sampling profiler.
+- [Heap Seance](https://github.com/SegfaultSorcerer/heap-seance) - Memory leak diagnostics that orchestrates jcmd, jmap, jstat, JFR, Eclipse MAT, and async-profiler into a structured investigation workflow with confidence-based verdicts.
 - [jHiccup](https://github.com/giltene/jHiccup) - Logs and records platform JVM stalls.
 - [JITWatch](https://github.com/AdoptOpenJDK/jitwatch) - Analyze the JIT compiler optimisations made by the HotSpot JVM.
 - [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM. (GPL-2.0 only WITH Classpath-exception-2.0)


### PR DESCRIPTION
## Add Heap Seance — Java memory leak diagnostics

**Repository:** https://github.com/SegfaultSorcerer/heap-seance
**Category:** Performance analysis

### What it does

Orchestrates JVM diagnostic tools (jcmd, jmap, jstat, JFR, Eclipse MAT, async-profiler) into a structured memory leak investigation workflow with confidence-based verdicts.

- Two-stage escalation: conservative histogram + GC scan, conditional deep forensics
- Confidence model requiring independent signal corroboration (histogram growth + GC pressure + MAT/JFR)
- Supports Java 8+ targets

### Why it belongs here

While implemented in Python (as an MCP server / CLI), it exclusively targets JVM processes and orchestrates standard JDK tools (`jcmd`, `jmap`, `jstat`, `jfr`) and Java ecosystem tooling (Eclipse MAT, async-profiler). Similar to how fastThread and GCeasy are cloud-based analysis tools rather than Java libraries, Heap Seance is an external orchestrator for JVM diagnostics.

### License

MIT / Apache-2.0 (dual-licensed)