### PR TITLE
Add ReleaseRun Maven Dependency Health checker to Build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ _Tools that handle the build cycle and dependencies of an application._
 - [Bazel](https://bazel.build) - Tool from Google that builds code quickly and reliably.
 - [Buck2](https://github.com/facebook/buck2) - Encourages the creation of small, reusable modules consisting of code and resources.
 - [Gradle](https://gradle.org) - Incremental builds programmed via Groovy instead of declaring XML. Works well with Maven's dependency management.
+- [ReleaseRun Maven Dependency Health](https://releaserun.com/tools/maven-dependency-health/) - A free web tool that checks any Maven dependency for latest version, EOL status, and known CVEs with an A–F health grade.
 
 ### Bytecode Manipulation
 


### PR DESCRIPTION
Adds a free web tool for checking Maven dependency health — latest version, EOL status, known CVEs, and A–F health grade. Fits the Build section under "Tools that handle the build cycle and dependencies of an application."

URL: https://releaserun.com/tools/maven-dependency-health/

Meets criteria (d): niche product that fills a gap — no other free web tool provides this for Maven dependencies specifically.