### PR TITLE
Add java-refined to Utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,6 +1236,7 @@ _Libraries which provide general utility functions._
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.
 - [JKScope](https://github.com/evpl/jkscope) - Java scope functions inspired by Kotlin.
+- [java-refined](https://github.com/JunggiKim/java-refined) - Refinement types for Java 8+ with 204 type-safe wrappers covering numerics, strings, and collections. Zero runtime dependencies.
 - [minio-java](https://github.com/minio/minio-java) - Provides simple APIs to access any Amazon S3-compatible object storage server.
 - [Protégé](https://protege.stanford.edu) - Provides an ontology editor and a framework to build knowledge-based systems.
 - [Semver4j](https://github.com/semver4j/semver4j) - Lightweight library that helps you handling semantic versioning with different modes.

--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,7 @@ _Libraries which provide general utility functions._
 - [JavaVerbalExpressions](https://github.com/VerbalExpressions/JavaVerbalExpressions) - Library that helps with constructing difficult regular expressions.
 - [JGit](https://www.eclipse.org/jgit/) - Lightweight, pure Java library implementing the Git version control system.
 - [JKScope](https://github.com/evpl/jkscope) - Java scope functions inspired by Kotlin.
-- [java-refined](https://github.com/JunggiKim/java-refined) - Refinement types for Java 8+ with 204 type-safe wrappers covering numerics, strings, and collections. Zero runtime dependencies.
+- [java-refined](https://github.com/JunggiKim/java-refined) - Zero-dependency refinement types for Java 8+ with type-safe wrappers covering numerics, strings, and collections.
 - [minio-java](https://github.com/minio/minio-java) - Provides simple APIs to access any Amazon S3-compatible object storage server.
 - [Protégé](https://protege.stanford.edu) - Provides an ontology editor and a framework to build knowledge-based systems.
 - [Semver4j](https://github.com/semver4j/semver4j) - Lightweight library that helps you handling semantic versioning with different modes.


### PR DESCRIPTION
## Summary

- Add [java-refined](https://github.com/JunggiKim/java-refined) to the **Utility** section

**java-refined** provides refinement types for Java 8+ — types constrained by predicates that make invalid states unrepresentable at the type level.

- **204 refined types** out of the box (numeric, string, collection, character, control)
- **Zero runtime dependencies** — just the JDK
- **Java 8+** compatible
- **100% test coverage**, 95%+ mutation testing score
- **MIT License**
- Published on **Maven Central**: `io.github.junggikim:java-refined:1.1.0`

Inspired by Scala's [refined](https://github.com/fthomas/refined) and Rust's [nutype](https://github.com/greyblake/nutype).