### PR TITLE
Add skipper-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,7 @@ _Other stuff related to testing._
 - [pojo-tester](https://www.pojo.pl) - Automatically performs tests on basic POJO methods. (LGPL-3.0-only)
 - [raml-tester](https://github.com/nidi3/raml-tester) - Tests if a request/response matches a given RAML definition.
 - [Selfie](https://github.com/diffplug/selfie) - Snapshot testing (inline and on disk).
+- [skipper-java](https://github.com/get-skipper/skipper-java) - Real-time test execution control via Google Spreadsheet, enabling instant toggle without code changes.
 - [Stebz](https://github.com/stebz/stebz) - Multi-approach framework for test steps managing.
 - [Testcontainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 


### PR DESCRIPTION
Add [skipper-java](https://github.com/get-skipper/skipper-java) to the Testing > Miscellaneous section.

Skipper fills a niche gap: unlike other testing utilities that focus on execution or assertions, skipper-java provides real-time test execution control via a shared Google Spreadsheet. Non-technical stakeholders (QA, product teams) can toggle tests instantly without code changes or deployments — unique in the Java testing ecosystem.

- MIT license
- English documentation
- GitHub: https://github.com/get-skipper/skipper-java