### PR TITLE
Add Spring CRUD Generator to Code Generators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ _Tools that generate patterns for repetitive code in order to reduce verbosity a
 - [JSpecify Package-Info Generator](https://github.com/bcaillard/jspecify-packageinfo-generator) - Maven plugin that automatically generates package-info.java files with JSpecify annotations (@NullMarked and @NullUnmarked), helping you manage nullness boundaries in your Java projects without manual boilerplate.
 - [Lombok](https://projectlombok.org) - Code generator that aims to reduce verbosity.
 - [Record-Builder](https://github.com/Randgalt/record-builder) - Companion builder class, withers and templates for Java records.
-- [Spring CRUD Generator](https://github.com/mzivkovicdev/spring-crud-generator) - Maven plugin for generating production-ready Spring Boot CRUD applications from YAML/JSON specs.
+- [Spring CRUD Generator](https://github.com/mzivkovicdev/spring-crud-generator) - Maven plugin for generating Spring Boot CRUD applications from YAML/JSON specifications.
 - [Telosys](https://www.telosys.org/) - Simple and light code generator available as an Eclipse Plugin and also as a CLI.
 
 ### Compiler-compiler

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ _Tools that generate patterns for repetitive code in order to reduce verbosity a
 - [JSpecify Package-Info Generator](https://github.com/bcaillard/jspecify-packageinfo-generator) - Maven plugin that automatically generates package-info.java files with JSpecify annotations (@NullMarked and @NullUnmarked), helping you manage nullness boundaries in your Java projects without manual boilerplate.
 - [Lombok](https://projectlombok.org) - Code generator that aims to reduce verbosity.
 - [Record-Builder](https://github.com/Randgalt/record-builder) - Companion builder class, withers and templates for Java records.
+- [Spring CRUD Generator](https://github.com/mzivkovicdev/spring-crud-generator) - Maven plugin for generating production-ready Spring Boot CRUD applications from YAML/JSON specs.
 - [Telosys](https://www.telosys.org/) - Simple and light code generator available as an Eclipse Plugin and also as a CLI.
 
 ### Compiler-compiler


### PR DESCRIPTION
Add Spring CRUD Generator to the awesome-java list.

This PR adds the [Spring CRUD Generator](https://github.com/mzivkovicdev/spring-crud-generator) project to the Code Generators section.

Spring CRUD Generator is a Maven plugin that generates production-ready Spring Boot backend boilerplate from a single YAML or JSON configuration file, including entities, repositories, services, DTOs, REST controllers, migrations, OpenAPI docs, tests, and more.