### PR TITLE
Add a link to ClearConfig for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ _Libraries that provide external configuration._
 
 - [avaje config](https://avaje.io/config/) - Loads yaml and properties files, supports dynamic configuration, plugins, file-watching and config event listeners.
 - [centraldogma](https://github.com/line/centraldogma) - Highly-available version-controlled service configuration repository based on Git, ZooKeeper and HTTP/2.
+- [ClearConfig](https://github.com/japgolly/clear-config-java) - A modern, type-safe, and highly-composable configuration library with a focus on runtime clarity.
 - [config](https://github.com/lightbend/config) - Configuration library supporting Java properties, JSON or its human optimized superset HOCON.
 - [Configurate](https://github.com/SpongePowered/Configurate) - Configuration library with support for various configuration formats and transformations.
 - [Curator Framework](https://curator.apache.org/) - High-level API for Apache ZooKeeper.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ _Libraries that provide external configuration._
 
 - [avaje config](https://avaje.io/config/) - Loads yaml and properties files, supports dynamic configuration, plugins, file-watching and config event listeners.
 - [centraldogma](https://github.com/line/centraldogma) - Highly-available version-controlled service configuration repository based on Git, ZooKeeper and HTTP/2.
-- [ClearConfig](https://github.com/japgolly/clear-config-java) - A modern, type-safe, and highly-composable configuration library with a focus on runtime clarity.
+- [ClearConfig](https://github.com/japgolly/clear-config-java) - Type-safe, composable configuration library with a focus on runtime clarity.
 - [config](https://github.com/lightbend/config) - Configuration library supporting Java properties, JSON or its human optimized superset HOCON.
 - [Configurate](https://github.com/SpongePowered/Configurate) - Configuration library with support for various configuration formats and transformations.
 - [Curator Framework](https://curator.apache.org/) - High-level API for Apache ZooKeeper.


### PR DESCRIPTION
> - Write about it's unique selling point compared to other projects.

This configuration library comes with a runtime report that details exactly what config what used (and unused), and where it all came from.