### PR TITLE
Add Sift to Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,7 @@ _Libraries which provide general utility functions._
 - [minio-java](https://github.com/minio/minio-java) - Provides simple APIs to access any Amazon S3-compatible object storage server.
 - [Protégé](https://protege.stanford.edu) - Provides an ontology editor and a framework to build knowledge-based systems.
 - [Semver4j](https://github.com/semver4j/semver4j) - Lightweight library that helps you handling semantic versioning with different modes.
+- [Sift](https://github.com/Mirkoddd/Sift) - Type-safe, AST-based Regex Builder focused on readability and ReDoS prevention.
 - [Underscore-java](https://github.com/javadev/underscore-java) - Port of Underscore.js functions.
 
 ### Version Managers


### PR DESCRIPTION
Hi maintainers!
I am the author of Sift. I know self-promotion is viewed critically, but the library recently crossed 20,000 downloads on Maven Central and fills a significant gap in the Java ecosystem regarding compile-time regex safety and ReDoS/CRLF prevention.

It has zero external dependencies, comprehensive English documentation, and is licensed under Apache 2.0. I believe it would be a valuable addition to the Utility section.
I've carefully ensured the entry is strictly alphabetized and followed formatting guidelines. Thank you for your time!