### PR TITLE
Add TheCodeForge to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ _Sites to read._
 - [Java, SQL, and jOOQ](https://blog.jooq.org)
 - [Java.net](https://community.oracle.com/community/java)
 - [Javalobby](https://dzone.com/java-jdk-development-tutorials-tools-news)
+- [TheCodeForge Java Tutorials](https://thecodeforge.io/java/)
 - [JavaWorld](https://www.javaworld.com)
 - [JAXenter](https://jaxenter.com)
 - [RebelLabs](https://zeroturnaround.com/rebellabs)


### PR DESCRIPTION
## Description

Adding TheCodeForge Java tutorials to the Resources > Websites section.

## Line to add (under Resources > Websites, alphabetically between "T" entries)

- [TheCodeForge Java](https://thecodeforge.io/java/) - Free tutorials covering OOP, collections, multithreading, design patterns and Spring Boot with plain-English explanations followed by real code and interview questions

## Checklist
- [x] The entry follows the format: `- [Name](URL) - Description`
- [x] The link is working and free
- [x] No duplication with existing entries
- [x] Added in alphabetical order
