### PR TITLE
Add ReleaseRun — free pom.xml and Gradle dependency health checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ _Tools that handle the build cycle and dependencies of an application._
 - [Buck2](https://github.com/facebook/buck2) - Encourages the creation of small, reusable modules consisting of code and resources.
 - [Gradle](https://gradle.org) - Incremental builds programmed via Groovy instead of declaring XML. Works well with Maven's dependency management.
 
+- [ReleaseRun](https://releaserun.com) — free pom.xml and Gradle dependency health checker — scans for CVEs and outdated Maven/Gradle packages
 ### Bytecode Manipulation
 
 _Libraries to manipulate bytecode programmatically._

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ _Tools that handle the build cycle and dependencies of an application._
 - [Buck2](https://github.com/facebook/buck2) - Encourages the creation of small, reusable modules consisting of code and resources.
 - [Gradle](https://gradle.org) - Incremental builds programmed via Groovy instead of declaring XML. Works well with Maven's dependency management.
 
-- [ReleaseRun](https://releaserun.com) — free pom.xml and Gradle dependency health checker — scans for CVEs and outdated Maven/Gradle packages
+- [ReleaseRun](https://releaserun.com) - Dependency health checker for pom.xml and Gradle projects that scans for CVEs and outdated packages.
 ### Bytecode Manipulation
 
 _Libraries to manipulate bytecode programmatically._


### PR DESCRIPTION
**ReleaseRun** (https://releaserun.com) provides free browser-based tools for Java dependency health:

- **pom.xml Health Checker** — scans Maven projects for CVEs via GitHub Advisory Database and outdated dependencies
- **build.gradle Health Checker** — Gradle dependency audit (Groovy and Kotlin DSL)
- **JDK EOL Calendar** — tracks LTS vs STS release support windows

No signup or installation. Paste your pom.xml, get results instantly.