### PR TITLE
Add AliveJTUI to Text-Based User Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ _Libraries to assist with parsing command line arguments._
 
 _Libraries that provide TUI frameworks, or building blocks related functions._
 
+- [AliveJTUI](https://github.com/yehorsyrin/alivejTUI) - Declarative, React-style TUI library. Build terminal UIs as component trees with diff-based rendering, focus management, themes, and a rich widget library.
 - [Jansi](https://github.com/fusesource/jansi) - ANSI escape codes to format console output.
 - [Jexer](https://gitlab.com/AutumnMeowMeow/jexer) - Advanced console (and Swing) text user interface (TUI) library, with mouse-draggable windows, built-in terminal window manager, and sixel image support. Looks like [Turbo Vision](https://en.wikipedia.org/wiki/Turbo_Vision).
 - [Text-IO](https://github.com/beryx/text-io) - Aids the creation of full console-based applications.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ _Libraries to assist with parsing command line arguments._
 
 _Libraries that provide TUI frameworks, or building blocks related functions._
 
-- [AliveJTUI](https://github.com/yehorsyrin/alivejTUI) - Declarative, React-style TUI library. Build terminal UIs as component trees with diff-based rendering, focus management, themes, and a rich widget library.
+- [AliveJTUI](https://github.com/yehorsyrin/alivejTUI) - Declarative, React-style TUI library for building terminal UIs as component trees with diff-based rendering, focus management, and themes.
 - [Jansi](https://github.com/fusesource/jansi) - ANSI escape codes to format console output.
 - [Jexer](https://gitlab.com/AutumnMeowMeow/jexer) - Advanced console (and Swing) text user interface (TUI) library, with mouse-draggable windows, built-in terminal window manager, and sixel image support. Looks like [Turbo Vision](https://en.wikipedia.org/wiki/Turbo_Vision).
 - [Text-IO](https://github.com/beryx/text-io) - Aids the creation of full console-based applications.


### PR DESCRIPTION
## Add AliveJTUI — declarative TUI library for Java

[AliveJTUI](https://github.com/yehorsyrin/alivejTUI) is a React-style TUI library for Java. It models terminal UIs as component trees with a virtual-node diff engine, so only changed cells are redrawn.

**Key features:**
- Declarative component model (`Component` → `Node` tree → diff → render)
- Rich widget library: buttons, inputs, checkboxes, radio groups, selects, tables, virtual lists, dialogs, toasts, and more
- Focus management (Tab/Shift+Tab), theme system (Dark/Light), CSS-like selectors
- Async state updates, timers/animations, undo/redo stack
- Pluggable backends (Lanterna, Mock)
- Available on Maven Central (`io.github.yehorsyrin:alivejTUI:0.1.1`)
- [Documentation](https://yehorsyrin.github.io/alivejTUI)

Fits the **Text-Based User Interfaces** section alongside Lanterna and Jexer, offering a higher-level declarative API on top of the terminal.