### PR TITLE
Add JamJet — agent-native runtime with Java SDK, MCP, and A2A support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ _Frameworks and libraries that help implementing and verifying design and archit
 
 _Frameworks that help you to leverage LLMs and AI._
 
+- [JamJet](https://github.com/jamjet-labs/jamjet) - Production-grade agent runtime with native Java SDK featuring agent strategies, graph-based workflow orchestration, multi-agent coordination, built-in eval harness, and native MCP and A2A protocol support. Rust core for performance with polyglot IR compilation.
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
 - [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ _Frameworks and libraries that help implementing and verifying design and archit
 
 _Frameworks that help you to leverage LLMs and AI._
 
-- [JamJet](https://github.com/jamjet-labs/jamjet) - Production-grade agent runtime with native Java SDK featuring agent strategies, graph-based workflow orchestration, multi-agent coordination, built-in eval harness, and native MCP and A2A protocol support. Rust core for performance with polyglot IR compilation.
+- [JamJet](https://github.com/jamjet-labs/jamjet) - Agent runtime with a Java SDK for building AI agents, supporting graph-based workflow orchestration, multi-agent coordination, and MCP/A2A protocols.
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
 - [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.


### PR DESCRIPTION
## What

Adds [JamJet](https://github.com/jamjet-labs/jamjet) to the Artificial Intelligence section.

## Why

JamJet fills a unique niche in the Java AI ecosystem — a production-grade agent runtime (not another LLM wrapper). While Spring AI and LangChain4j handle model abstraction, and MCP Java SDK handles protocol, JamJet provides the runtime layer:

- **Agent strategies** — react, plan-and-execute, critic (built-in, not LLM-dependent)
- **Graph-based workflow orchestration** — typed state, conditional routing, durable execution
- **Multi-agent coordination** — CoordinatorNode with structured scoring and LLM tiebreaker
- **Native MCP client/server + A2A protocol** — first-class protocol interoperability
- **Built-in eval harness** — LLM judge, assertions, cost tracking
- **Java SDK** — records, virtual threads, fluent builder API (JDK 21+)
- **Rust core (Tokio)** — polyglot IR compilation, Python and Java compile to same runtime
- Published on **Maven Central** (`dev.jamjet:jamjet-sdk`, Spring Boot starter, LangChain4j integration)
- **License:** Apache 2.0

Complements the existing entries (Spring AI, LangChain4j, MCP Java SDK) rather than overlapping — positioned as the production runtime layer underneath.