### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [Apache Shiro](https://shiro.apache.org) - Performs authentication, authorization, cryptography and session management.
 - [Ayza](https://github.com/Hakky54/ayza) - High-level SSL configuration builder for configuring HTTP clients and servers with SSL/TLS.
 - [Bouncy Castle](https://www.bouncycastle.org/java.html) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
-- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - Extract server certificates.
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - CLI tool and library for extracting and exporting server certificates from HTTPS endpoints.
 - [DependencyCheck](https://github.com/jeremylong/DependencyCheck) - Detects publicly disclosed vulnerabilities contained within a project's dependencies.
 - [Cryptomator](https://cryptomator.org) - Multiplatform, transparent, client-side encryption of files in the cloud. (GPL-3.0-only)
 - [Hdiv](https://github.com/hdiv/hdiv) - Runtime application that repels application security risks included in the OWASP Top 10, including SQL injection, cross-site scripting, cross-site request forgery, data tampering, and brute force attacks.

--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ _Libraries that handle security, authentication, authorization or session manage
 - [Apache Shiro](https://shiro.apache.org) - Performs authentication, authorization, cryptography and session management.
 - [Ayza](https://github.com/Hakky54/ayza) - High-level SSL configuration builder for configuring HTTP clients and servers with SSL/TLS.
 - [Bouncy Castle](https://www.bouncycastle.org/java.html) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - Extract server certificates.
 - [DependencyCheck](https://github.com/jeremylong/DependencyCheck) - Detects publicly disclosed vulnerabilities contained within a project's dependencies.
 - [Cryptomator](https://cryptomator.org) - Multiplatform, transparent, client-side encryption of files in the cloud. (GPL-3.0-only)
 - [Hdiv](https://github.com/hdiv/hdiv) - Runtime application that repels application security risks included in the OWASP Top 10, including SQL injection, cross-site scripting, cross-site request forgery, data tampering, and brute force attacks.


### PR DESCRIPTION
[Certificate ripper](https://github.com/Hakky54/certificate-ripper) extracts server certifcates including the full chain into a der, p7b, pkcs12 or pem file. It makes it easy to update/maintain truststores or for analysing certificates.

Example usage:

Add the dependency
```xml
<dependency>
    <groupId>io.github.hakky54</groupId>
    <artifactId>certificate-ripper</artifactId>
    <version>2.7.1</version>
</dependency>
```
Run the code snippet
```java
public class App {
 
     public static void main(String[] args) {
         CertificateRipper.exportToPem("https://github.com")
                 .withIncludeHeader(false)
                 .withCombined(true)
                 .withDestination("/path/to/export/github-chain.crt")
                 .build()
                 .run();
     }
 
 }
```