### PR TITLE
add parallel-collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ _Libraries that facilitate functional programming._
 - [Functional Java](http://www.functionaljava.org) - Implements numerous basic and advanced programming abstractions that assist composition-oriented development.
 - [jOOλ](https://github.com/jOOQ/jOOL) - Extension to Java 8 that aims to fix gaps in lambda by providing numerous missing types and a rich set of sequential Stream API additions.
 - [Packrat](https://github.com/jhspetersson/packrat) - Gatherers library for Java Stream API. Gatherers can enhance streams with custom intermediate operations.
+- [Parallel Collectors](https://github.com/pivovarit/parallel-collectors) - Stream API Collectors for parallel processing with custom thread pools, designed for I/O-heavy workloads.
 - [protonpack](https://github.com/poetix/protonpack) - Collection of stream utilities.
 - [StreamEx](https://github.com/amaembo/streamex) - Enhances Java 8 Streams.
 - [Vavr](https://www.vavr.io) - Functional component library that provides persistent data types and functional control structures.


### PR DESCRIPTION
  - [x] Niche product filling a gap: enables parallel Stream processing with custom thread pools and Virtual Threads for
  I/O-heavy workloads, which standard parallel streams don't support
  - [x] Licensed under Apache-2.0
  - [x] Documentation in English