### PR TITLE
Add Kensa to the list of BDD frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,7 @@ _Testing for the software development process that emerged from TDD and was heav
 - [J8Spec](https://github.com/j8spec/j8spec) - Follows a Jasmine-like syntax.
 - [JBehave](https://jbehave.org) - Extensively configurable framework that describes stories.
 - [JGiven](http://jgiven.org) - Provides a fluent API which allows for simpler composition.
+- [Kensa](https://github.com/kensa-dev/kensa) - Code-first BDD for Java & Kotlin — write Given-When-Then tests in code, get rich interactive HTML reports and sequence diagrams.
 - [Lamdba Behave](https://github.com/RichardWarburton/lambda-behave) - Aims to provide a fluent API to write tests in long and descriptive sentences that read like plain English.
 - [Serenity BDD](https://github.com/serenity-bdd/serenity-core) - Automated Acceptance testing and reporting library that works with Cucumber, JBehave and JUnit to make it easier to write high quality executable specifications.
 

--- a/README.md
+++ b/README.md
@@ -1140,7 +1140,7 @@ _Testing for the software development process that emerged from TDD and was heav
 - [J8Spec](https://github.com/j8spec/j8spec) - Follows a Jasmine-like syntax.
 - [JBehave](https://jbehave.org) - Extensively configurable framework that describes stories.
 - [JGiven](http://jgiven.org) - Provides a fluent API which allows for simpler composition.
-- [Kensa](https://github.com/kensa-dev/kensa) - Code-first BDD for Java & Kotlin — write Given-When-Then tests in code, get rich interactive HTML reports and sequence diagrams.
+- [Kensa](https://github.com/kensa-dev/kensa) - Code-first BDD framework for Java and Kotlin that generates interactive HTML reports and sequence diagrams from test code.
 - [Lamdba Behave](https://github.com/RichardWarburton/lambda-behave) - Aims to provide a fluent API to write tests in long and descriptive sentences that read like plain English.
 - [Serenity BDD](https://github.com/serenity-bdd/serenity-core) - Automated Acceptance testing and reporting library that works with Cucumber, JBehave and JUnit to make it easier to write high quality executable specifications.
 


### PR DESCRIPTION
Kensa is a BDD testing framework for Kotlin and Java that takes a code-first approach — tests are written as plain Given-When-Then code with no Gherkin files and no step definitions.                                                                     
                                                                                                                                                                                                                                                             
HTML reports are generated directly from the source code so reports are never stale.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                             
Also includes built-in sequence diagram generation and supports JUnit 5 & 6, Kotest, and TestNG.  