### PR TITLE
Add jDRPC to Microservice section

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ _Tools for creating and managing microservices._
 - [Eureka](https://github.com/Netflix/eureka) - REST-based service registry for resilient load balancing and failover.
 - [Helidon](https://helidon.io) - Two-style approach for writing microservices: Functional-reactive and as an implementation of MicroProfile.
 - [JDA](https://github.com/DV8FromTheWorld/JDA) - Wrapping of the Discord REST API and its WebSocket events.
+- [jDRPC](https://github.com/CrashSystemZ/jDRPC) - Lightweight Java 17 library for Discord IPC/Rich Presence with no native dependencies.
 - [KeenType](https://github.com/DaveJarvis/KeenType) - Modernized version of a Java-based implementation of the New Typesetting System, which was heavily based on Donald E. Knuth's original TeX.
 - [kubernetes-client](https://github.com/fabric8io/kubernetes-client) - Client provides access to the full Kubernetes & OpenShift REST APIs via a fluent DSL.
 - [Micronaut](https://micronaut.io) - Modern full-stack framework with focus on modularity, minimal memory footprint and startup time.


### PR DESCRIPTION
jDRPC fills a gap (condition d) in the Java ecosystem. The closest alternative for Discord IPC is JavaDiscordRPC, which is over 9 years old and unmaintained. Other active libraries that implement Rich Presence do so via native DLL bindings rather than the IPC protocol itself, introducing a native dependency. jDRPC is a pure Java 17 implementation over IPC (Unix domain sockets / named pipes) with no native dependencies, a modern fluent API and inline documentation.