### PR TITLE
Add link to Awesome Java Related Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,7 @@ _Awesome Lists related to the Java & JVM ecosystem._
 - [Awesome Graal](https://github.com/neomatrix369/awesome-graal)
 - [Awesome Gradle Plugins](https://github.com/ksoichiro/awesome-gradle)
 - [Awesome Java libraries and hidden gems](https://libs.tech/java)
+- [Awesome Java Related Repositories](https://relatedrepos.com/gh/akullpp/awesome-java)
 - [Awesome J2ME](https://github.com/hstsethi/awesome-j2me)
 - [AwesomeJavaFX](https://github.com/mhrimaz/AwesomeJavaFX)
 - [Awesome JVM](https://github.com/deephacks/awesome-jvm)


### PR DESCRIPTION
Added a link for users to explore open source repositories that are related to `akullpp/awesome-java`.

[Related Repos](https://relatedrepos.com/) helps developers to discover open source projects that are related to each other. This can be useful to find alternative or complementary packages when building a full application. Or you can simply surf around in different neighborhoods to find new ideas that you might not have been aware of.