### PR TITLE
feat(template-engine): add NRG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ _Tools that substitute expressions in a template._
 - [jstachio](https://github.com/jstachio/jstachio) - Typesafe Mustache templating engine.
 - [jte](https://github.com/casid/jte) - Compiles to classes, and uses an easy syntax, several features to make development easier and provides fast execution and a small footprint.
 - [Jtwig](https://github.com/jtwig/jtwig) - Modular, configurable and fully tested template engine.
+- [NRG](https://github.com/nanolaba/readme-generator) - Markdown-focused template engine that generates multi-language README files from a single `.src.md` source via file imports, custom widgets and a built-in TOC; ships as CLI, Maven plugin and Java library.
 - [Pebble](https://pebbletemplates.io) - Inspired by Twig and separates itself with its inheritance feature and its easy-to-read syntax. It ships with built-in autoescaping for security and it includes integrated support for internationalization.
 - [Rocker](https://github.com/fizzed/rocker) - Optimized, memory efficient and speedy template engine producing statically typed, plain objects.
 - [StringTemplate](https://github.com/antlr/stringtemplate4) - Template engine for generating source code, web pages, emails, or any other formatted text output.


### PR DESCRIPTION
Adds **NRG** (Nanolaba Readme Generator) to the `Template Engine` section, alphabetized between `Jtwig` and `Pebble`.

### Why it qualifies

Per `CONTRIBUTING.md` criteria:

- **(c) Absolutely unique in its approach and function** — every existing entry in `Template Engine` (Freemarker, Handlebars.java, Jamal, jstachio, jte, Jtwig, Pebble, Rocker, StringTemplate, Thymeleaf) is a *general-purpose* engine targeting HTML, source code or arbitrary text. NRG is the only entry purpose-built for **Markdown documentation**, with first-class support for *generating multiple language variants* (e.g. `README.md` and `README.ru.md`) from a single `.src.md` source — neither use case is covered by the existing entries.
- **(d) Niche product that fills a gap** — there is currently no Java tool in this list that targets multi-language README/documentation generation.

### Distinguishing features (per PR rule 1)

- Multi-language output from a single template via `${en:'…', ru:'…'}` substitution.
- File imports, custom widgets, and a built-in table-of-contents widget.
- Distributed as **CLI**, **Maven plugin** (`com.nanolaba:nrg-maven-plugin`), and **Java library** — covers both ad-hoc and build-pipeline use cases.

### Compliance

- License: MIT (OSI-approved, non-viral) ✓ (criterion ii)
- English documentation ✓ (criterion iv)
- Repo: https://github.com/nanolaba/readme-generator
- Maven Central: https://central.sonatype.com/artifact/com.nanolaba/readme-generator
- Format: `[NAME](LINK) - DESCRIPTION.` ✓
- Alphabetical order ✓
- Single addition, single PR ✓