### PR TITLE
Add sealed-env to Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ _Libraries that provide external configuration._
 - [KAConf](https://github.com/mariomac/kaconf) - Annotation-based configuration system for Java and Kotlin.
 - [microconfig](https://microconfig.io) - Configuration system designed for microservices which helps to separate configuration from code. The configuration for different services can have common and specific parts and can be dynamically distributed.
 - [owner](https://github.com/lviggiano/owner) - Reduces boilerplate of properties.
+- [sealed-env](https://github.com/davidalmeidac/sealed-env) - Cross-stack (Java + Node.js) library for encrypted .env files at rest, with optional TOTP-bound unsealing for production deploys. Spring Boot Starter included. Public threat model.
 
 ### Constraint Satisfaction Problem Solver
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ _Libraries that provide external configuration._
 - [KAConf](https://github.com/mariomac/kaconf) - Annotation-based configuration system for Java and Kotlin.
 - [microconfig](https://microconfig.io) - Configuration system designed for microservices which helps to separate configuration from code. The configuration for different services can have common and specific parts and can be dynamically distributed.
 - [owner](https://github.com/lviggiano/owner) - Reduces boilerplate of properties.
-- [sealed-env](https://github.com/davidalmeidac/sealed-env) - Cross-stack (Java + Node.js) library for encrypted .env files at rest, with optional TOTP-bound unsealing for production deploys. Spring Boot Starter included. Public threat model.
+- [sealed-env](https://github.com/davidalmeidac/sealed-env) - Encrypts environment files with a shared Node.js and Java/Spring Boot format plus optional TOTP unsealing.
 
 ### Constraint Satisfaction Problem Solver
 


### PR DESCRIPTION
Adds [sealed-env](https://github.com/davidalmeidac/sealed-env) to the Configuration section.

Cross-stack library (Java + Node.js) for encrypted .env files at rest, with optional TOTP-bound unsealing for production deploys. Designed against real 2024-2025 supply-chain attacks (Shai-Hulud, tj-actions/changed-files, GhostAction). Spring Boot Starter included.

Per CONTRIBUTING.md: unique selling point is the cross-stack wire format compatible across Node and Java/Spring Boot, public threat model, and TOTP-bound deploys. Not a commercial project. MIT licensed, published on Maven Central (io.github.davidalmeidac) and npm (sealed-env). Description ends with a dot. Entry placed alphabetically (after owner).

Happy to adjust placement or wording on review.