### PR TITLE
ADD JVM Monitoring Orchestration Tools - Argus

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,7 +970,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM. (GPL-2.0 only WITH Classpath-exception-2.0)
 - [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.
 - [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis to identify algorithmic bottlenecks.
-- [Argus](https://github.com/rlaope/Argus) - JVM Monitoring Orchestration Tools.
+- [Argus](https://github.com/rlaope/Argus) - JVM diagnostics CLI for jcmd, JFR, async-profiler, heap analysis and machine-readable health verdicts.
 
 ### Platform
 

--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - Harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targeting the JVM. (GPL-2.0 only WITH Classpath-exception-2.0)
 - [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.
 - [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis to identify algorithmic bottlenecks.
+- [Argus](https://github.com/rlaope/Argus) - JVM Monitoring Orchestration Tools.
 
 ### Platform
 


### PR DESCRIPTION
Adds Argus to the Performance analysis section.

JVM diagnostic orchestration tool that consolidates jcmd, async-profiler, JFR, and NMT behind a single agentless CLI plus a live TUI/web dashboard, rule-based doctor, and a continuous trend-aware harness. Distinct from the existing Heap Seance entry, which scopes itself to memory leak diagnostics only — Argus covers the full JVM diagnostic surface (GC, threads, JFR, NMT, code cache, deoptimization counters, async-profiler) through one tool with multiple delivery surfaces.

Per CONTRIBUTING.md: unique selling point is full-surface JVM diagnostic orchestration with both interactive (CLI/TUI/dashboard) and machine-readable (JSON/exit codes) outputs, plus a doctor that produces severity-ranked findings with JVM-flag suggestions. Not a commercial project. MIT licensed (listed on opensource.org). English documentation at <https://rlaope.github.io/Argus/>. Description ends with a dot. Entry placed at the end of Performance analysis after JVM Hotpath — matching the existing list's loose ordering convention.

Happy to adjust placement or wording on review.