### PR TITLE
Add Javalin to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ _Tools for creating and managing microservices._
 - [KeenType](https://github.com/DaveJarvis/KeenType) - Modernized version of a Java-based implementation of the New Typesetting System, which was heavily based on Donald E. Knuth's original TeX.
 - [kubernetes-client](https://github.com/fabric8io/kubernetes-client) - Client provides access to the full Kubernetes & OpenShift REST APIs via a fluent DSL.
 - [Micronaut](https://micronaut.io) - Modern full-stack framework with focus on modularity, minimal memory footprint and startup time.
+- [Javalin](https://github.com/javalin/javalin) - Lightweight REST framework for Java and Kotlin.
 - [Nacos](https://nacos.io) - Dynamic service discovery, configuration and service management platform for building cloud native applications.
 - [OpenAI-Java](https://github.com/TheoKanning/openai-java) - Java libraries for using OpenAI's GPT-3 API.
 - [Quarkus](https://quarkus.io) - Kubernetes stack tailored for the HotSpot and Graal VM.


### PR DESCRIPTION
Added Javalin - lightweight REST framework for Java and Kotlin.