### PR TITLE
feat(document-processing): add jackson-dataformat-spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ _Libraries that assist with processing office document formats._
 - [documents4j](https://documents4j.com/#/) - API for document format conversion using third-party converters such as MS Word.
 - [docx4j](https://www.docx4java.org/trac/docx4j) - Create and manipulate Microsoft Open XML files.
 - [fastexcel](https://github.com/dhatim/fastexcel) - High performance library to read and write large Excel (XLSX) worksheets.
+- [jackson-dataformat-spreadsheet](https://github.com/scndry/jackson-dataformat-spreadsheet) - Jackson dataformat module for reading and writing Excel (XLSX/XLS) as POJOs via `ObjectMapper`.
 - [Sheetz](https://github.com/chitralabs/sheetz) - Library for reading and writing Excel and CSV files with annotation-based mapping, streaming support, and built-in validation.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
 


### PR DESCRIPTION
Adds jackson-dataformat-spreadsheet — a Jackson dataformat module for reading and writing Excel (XLSX/XLS) as POJOs via the standard `ObjectMapper` API. Existing Jackson annotations (`@JsonIgnore`, `@JsonAlias`, `@JsonView`, MixIn, custom serializers) apply unchanged. Listed in the FasterXML/jackson community data-format modules.