### PR TITLE
Add traceAI to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ _Tools that observe/monitor applications in production by providing telemetry._
 - [SPM ![c]](https://github.com/sematext/sematext-agent-java) - Performance monitor with distributing transaction tracing for JVM apps.
 - [Stagemonitor](https://github.com/stagemonitor/stagemonitor) - Open-source performance monitoring and transaction tracing for JVM apps.
 - [Sysmon](https://github.com/palantir/Sysmon) - Lightweight platform monitoring tool for Java VMs.
+- [traceAI](https://github.com/future-agi/traceAI) - OpenTelemetry-native distributed tracing for LLM and agent applications. Java SDK that auto-instruments OpenAI, Anthropic, Azure OpenAI, Bedrock, Cohere, Google GenAI, Ollama, and vector stores.
 - [zipkin](https://zipkin.io) - Distributed tracing system which gathers timing data needed to troubleshoot latency problems in microservice architectures.
 
 ### Native

--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ _Tools that observe/monitor applications in production by providing telemetry._
 - [SPM ![c]](https://github.com/sematext/sematext-agent-java) - Performance monitor with distributing transaction tracing for JVM apps.
 - [Stagemonitor](https://github.com/stagemonitor/stagemonitor) - Open-source performance monitoring and transaction tracing for JVM apps.
 - [Sysmon](https://github.com/palantir/Sysmon) - Lightweight platform monitoring tool for Java VMs.
-- [traceAI](https://github.com/future-agi/traceAI) - OpenTelemetry-native distributed tracing for LLM and agent applications. Java SDK that auto-instruments OpenAI, Anthropic, Azure OpenAI, Bedrock, Cohere, Google GenAI, Ollama, and vector stores.
+- [traceAI](https://github.com/future-agi/traceAI) - OpenTelemetry-native distributed tracing for LLM and agent applications with Java auto-instrumentation for major providers and vector stores.
 - [zipkin](https://zipkin.io) - Distributed tracing system which gathers timing data needed to troubleshoot latency problems in microservice architectures.
 
 ### Native


### PR DESCRIPTION
Adds [traceAI](https://github.com/future-agi/traceAI) to the **Monitoring** section, alphabetically between `Sysmon` and `zipkin`.

**Unique selling point vs. existing entries in the section:**

- **vs. OpenTelemetry (`opentelemetry-java`)**: traceAI is built on top of the OpenTelemetry Java SDK but ships AI-specific semantic conventions and 19+ ready-made auto-instrumentation modules for LLM providers (OpenAI, Anthropic, Azure OpenAI, Bedrock, Cohere, Google GenAI, Ollama) and vector stores (Pinecone, Qdrant, Milvus, ChromaDB, Elasticsearch, MongoDB, Redis). Plain OTel does not provide these.
- **vs. Jaeger client, zipkin, Micrometer Tracing**: those are general-purpose distributed-tracing exporters/facades. traceAI emits structured spans for LLM-specific signals: prompts, completions, tokens, tool calls, retrieval steps, model parameters. Use them as the export backend; traceAI provides the LLM-aware instrumentation layer.
- **vs. Datadog APM (`dd-trace-java`)**: traceAI is vendor-neutral and works with any OTel-compatible backend (Datadog, Grafana, Jaeger, etc.).

Open source (Apache 2.0). Multi-language project but the Java SDK is a first-class module (`traceai-java-*` artifacts via Maven, ships its own `pom.xml` and `jitpack.yml`).

Description finishes with a period and is concise.