### PR TITLE
Add JQuickCurl to HTTP Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ _Libraries that assist with creating HTTP requests and/or binding responses._
 - [Ribbon](https://github.com/Netflix/ribbon) - Client-side IPC library that is battle-tested in the cloud.
 - [Riptide](https://github.com/zalando/riptide) - Client-side response routing for Spring's RestTemplate.
 - [unirest-java](https://github.com/Kong/unirest-java) - Simplified, lightweight HTTP client library.
-
+- [JQuickCurl](https://github.com/paohaijiao/jquick-curl) - A Java HTTP client framework that allows developers to use native cURL syntax directly. Copy from Postman, paste into XML configuration, done. (Apache 2.0, 1.1k ⭐)
 ### Hypermedia Types
 
 _Libraries that handle serialization to hypermedia types._

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ _Libraries that assist with creating HTTP requests and/or binding responses._
 - [Ribbon](https://github.com/Netflix/ribbon) - Client-side IPC library that is battle-tested in the cloud.
 - [Riptide](https://github.com/zalando/riptide) - Client-side response routing for Spring's RestTemplate.
 - [unirest-java](https://github.com/Kong/unirest-java) - Simplified, lightweight HTTP client library.
-- [JQuickCurl](https://github.com/paohaijiao/jquick-curl) - A Java HTTP client framework that allows developers to use native cURL syntax directly. Copy from Postman, paste into XML configuration, done. (Apache 2.0, 1.1k ⭐)
+- [JQuickCurl](https://github.com/paohaijiao/jquick-curl) - Executes HTTP requests from cURL syntax through annotations, XML configuration and dynamic proxy clients.
 ### Hypermedia Types
 
 _Libraries that handle serialization to hypermedia types._


### PR DESCRIPTION
**Project**: JQuickCurl
**URL**: https://github.com/paohaijiao/jquick-curl
**Category**: HTTP Clients

**Description**:
A Java HTTP client framework that allows developers to use native cURL syntax directly. Copy cURL commands from Postman/website, paste into XML configuration, done.

**Checklist**:
- [x] 1.1k+ stars
- [x] Actively maintained (latest release Apr 2026)
- [x] Apache 2.0 license
- [x] Clear README in English and Chinese

**Why it fits**:
This project solves the pain point of rewriting HTTP requests in Java. Developers can just paste the cURL command and run, no need to learn RestTemplate or OkHttp.

Thanks for your consideration!