### PR TITLE
Add Regulus to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ _Frameworks that help you to leverage LLMs and AI._
 - [JamJet](https://github.com/jamjet-labs/jamjet) - Agent runtime with a Java SDK for building AI agents, supporting graph-based workflow orchestration, multi-agent coordination, and MCP/A2A protocols.
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
+- [Regulus](https://github.com/neul-labs/regulus) - EU & UK compliance plane for Google ADK encoding 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) as runtime `BasePlugin` profiles with hash-chained audit envelopes, PII redaction, dual-control kill switch, and GRC adapters (ServiceNow IRM, OneTrust, MetricStream).
 - [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.
 - [Spring AI](https://spring.io/projects/spring-ai) - Application framework for AI engineering for Spring.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ _Frameworks that help you to leverage LLMs and AI._
 - [JamJet](https://github.com/jamjet-labs/jamjet) - Agent runtime with a Java SDK for building AI agents, supporting graph-based workflow orchestration, multi-agent coordination, and MCP/A2A protocols.
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.
-- [Regulus](https://github.com/neul-labs/regulus) - EU & UK compliance plane for Google ADK encoding 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) as runtime `BasePlugin` profiles with hash-chained audit envelopes, PII redaction, dual-control kill switch, and GRC adapters (ServiceNow IRM, OneTrust, MetricStream).
+- [Regulus](https://github.com/neul-labs/regulus) - Google ADK plugin suite that adds runtime compliance profiles, audit envelopes and GRC adapters for regulated Java AI agents.
 - [simple-openai](https://github.com/sashirestela/simple-openai) - Library to use the OpenAI API (and compatible ones) in the simplest possible way.
 - [Spring AI](https://spring.io/projects/spring-ai) - Application framework for AI engineering for Spring.
 


### PR DESCRIPTION
Adds [Regulus](https://github.com/neul-labs/regulus) — the EU & UK compliance plane for Google ADK — to the **Artificial Intelligence** section.

Regulus is a Java 21, MIT-licensed runtime ADK `BasePlugin` suite that encodes 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) and 6 governance frameworks (NIST AI RMF, ISO/IEC 42001, ISO/IEC 23894, ISO/IEC 23053) as composable profiles. It emits hash-chained audit envelopes and ships GRC evidence adapters (ServiceNow IRM, OneTrust AI Governance, MetricStream, signed webhooks).

Fits the section per contributing criteria (c) and (d): unique approach (compliance plane built on ADK's plugin SPI) and a niche product that fills a gap (no other Java library encodes multi-regulator compliance as runtime ADK profiles).