### PR TITLE
Add test-watch-maven-plugin to Testing > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ _Other stuff related to testing._
 - [Stebz](https://github.com/stebz/stebz) - Multi-approach framework for test steps managing.
 - [Testcontainers](https://github.com/testcontainers/testcontainers-java) - Provides throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 - [Java Evolved](https://javaevolved.github.io/) - Side-by-side comparisons of legacy and modern Java patterns.
+- [test-watch-maven-plugin](https://github.com/albilu/test-watch-maven-plugin) - Maven plugin providing Vitest-inspired watch mode for tests with smart selection and parallel execution.
 
 #### Mocking
 


### PR DESCRIPTION
Adds [test-watch-maven-plugin](https://github.com/albilu/test-watch-maven-plugin) — a Maven plugin providing Vitest-inspired watch mode for tests with smart selection and parallel execution. MIT licensed, available on Maven Central.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `test-watch-maven-plugin` to Testing > Miscellaneous in the README. It provides a Vitest-inspired test watch mode for Maven with smart selection and parallel execution to speed up local development.

<sup>Written for commit 144c83368d18ac9a9622e7e7dabad7a709f7a49d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

