### PR TITLE
Add Wickra to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ _Libraries related to the financial domain._
 - [Square](https://github.com/square/connect-java-sdk) - Integration with the Square API.
 - [Stripe](https://github.com/stripe/stripe-java) - Integration with the Stripe API.
 - [ta4j](https://github.com/ta4j/ta4j) - Library for technical analysis.
+- [Wickra](https://github.com/wickra-lib/wickra) - Technical-analysis library with 514 streaming O(1)-per-tick indicators on a native Rust core, on Maven Central as org.wickra:wickra; more indicators and incremental updates than the pure-Java ta4j.
 
 ### Formal Verification
 


### PR DESCRIPTION
Adds Wickra to the Financial section (alphabetical, after ta4j).

Wickra is an open-source (MIT OR Apache-2.0, not GPL/AGPL) technical-analysis library with a Rust core, exposed to Java via its C ABI and published on Maven Central as org.wickra:wickra. English docs at docs.wickra.org.

How it differs from ta4j (the existing TA entry):
- 514 indicators across 24 families vs the ~130 of ta4j - including market microstructure, order-flow/derivatives, market profile and Ehlers DSP cycles.
- A native Rust core instead of a pure-Java reimplementation; every indicator updates in O(1) per tick.
- batch == streaming is bit-exact, fuzzed and 100%-line-covered for all 514, so backtest and live results match.
- The exact same engine is shared across nine languages (Python, Node.js, WASM, Rust, C, C++, C#, Go, R), not a Java-only port.

Repo: https://github.com/wickra-lib/wickra


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Wickra to the Financial libraries list in README, listed after ta4j. The entry links to the repo and notes the `org.wickra:wickra` Maven artifact and 514 O(1)-per-tick indicators on a Rust core.

<sup>Written for commit 3f59c4e322f08f0794b70b3319eaef1b98fa9cb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

