### PR TITLE
Add CRUDGen to Code Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ _Tools that generate patterns for repetitive code in order to reduce verbosity a
 - [Auto](https://github.com/google/auto) - Generates factory, service, and value classes.
 - [Avaje Http Server](https://avaje.io/http/) - Generates Lightweight JAX-RS style http servers using Javalin or Helidon (Nima) SE.
 - [Bootify ![c]](https://bootify.io) - Browser-based Spring Boot app generation with JPA model and REST API.
+- [CRUDGen](https://github.com/bariskokulu/CRUDGen) - Compile-time annotation processor generating CRUD layers, DTOs, JSON Patch, and custom HTTP endpoints for Spring Boot.
 - [EasyEntityToDTO](https://github.com/Marcel091004/EasyEntityToDTO) - Annotation processor for automatic DTO and Mapper generation with zero boilerplate.
 - [FreeBuilder](https://github.com/inferred/FreeBuilder) - Automatically generates the Builder pattern.
 - [Geci](https://github.com/verhas/javageci) - Discovers files that need generated code, updates automatically and writes to the source with a convenient API.


### PR DESCRIPTION
Adds CRUDGen to the Code Generators category.

CRUDGen fills a specific gap in the Spring Boot ecosystem. Unlike heavy scaffolding frameworks or runtime reflection-based tools, it is a strict compile-time annotation processor. It deterministically generates boilerplate REST layers, DTOs, N+1 safe queries, and JSON Patch endpoints during the build phase without adding any runtime dependencies or bloating the application size.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `CRUDGen` to the Code Generators list in README as a compile-time Spring Boot annotation processor that generates CRUD REST layers, DTOs, JSON Patch, and custom endpoints with no runtime dependencies.

<sup>Written for commit 75db1515dc20d9d303c2aff6c3e0e37acded5fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

