### PR TITLE
Add Nuts to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ _Everything else._
 - [LittleProxy](https://github.com/adamfisk/LittleProxy) - High performance HTTP proxy atop Netty's event-based networking library.
 - [Modern Java - A Guide to Java 8](https://github.com/winterbe/java8-tutorial) - Popular Java 8 guide.
 - [Modernizer](https://github.com/gaul/modernizer-maven-plugin) - Detect uses of legacy Java APIs.
+- [Nuts](https://github.com/thevpc/nuts) - Nuts – A portable package manager for the JVM that installs applications from Maven Central, provisions the required JDK automatically, and lets you run them anywhere without configuration overhead.
 - [Nyagram](https://github.com/kaleert/nyagram) - Reactive, type-safe framework for Telegram bots based on Spring Boot 3 and Java 21.
 - [OctoLinker](https://github.com/OctoLinker/OctoLinker) - Browser extension which allows to navigate through code on GitHub more efficiently.
 - [OpenRefine](http://openrefine.org) - Tool for working with messy data: cleaning, transforming, extending it with web services and linking it to databases.

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ _Tools that handle the distribution of applications in native formats._
 - [JavaPackager](https://github.com/fvarrui/JavaPackager) - Maven and Gradle plugin which provides an easy way to package Java applications in native Windows, macOS or GNU/Linux executables, and generate installers for them.
 - [jDeploy](https://www.jdeploy.com) - Deploy desktop apps as native Mac, Windows or Linux bundles.
 - [jlink.online](https://github.com/AdoptOpenJDK/jlink.online) - Builds optimized runtimes over HTTP.
+- [Nuts](https://github.com/thevpc/nuts) - Installs and runs Java applications from Maven repositories, reusing descriptors and provisioning required JDKs.
 - [Nexus ![c]](https://www.sonatype.com) - Binary management with proxy and caching capabilities.
 - [packr](https://github.com/libgdx/packr) - Packs JARs, assets and the JVM for native distribution on Windows, Linux and macOS.
 - [really-executable-jars-maven-plugin](https://github.com/brianm/really-executable-jars-maven-plugin) - Maven plugin for making self-executing JARs.
@@ -796,7 +797,6 @@ _Everything else._
 - [LittleProxy](https://github.com/adamfisk/LittleProxy) - High performance HTTP proxy atop Netty's event-based networking library.
 - [Modern Java - A Guide to Java 8](https://github.com/winterbe/java8-tutorial) - Popular Java 8 guide.
 - [Modernizer](https://github.com/gaul/modernizer-maven-plugin) - Detect uses of legacy Java APIs.
-- [Nuts](https://github.com/thevpc/nuts) - Nuts – A portable package manager for the JVM that installs applications from Maven Central, provisions the required JDK automatically, and lets you run them anywhere without configuration overhead.
 - [Nyagram](https://github.com/kaleert/nyagram) - Reactive, type-safe framework for Telegram bots based on Spring Boot 3 and Java 21.
 - [OctoLinker](https://github.com/OctoLinker/OctoLinker) - Browser extension which allows to navigate through code on GitHub more efficiently.
 - [OpenRefine](http://openrefine.org) - Tool for working with messy data: cleaning, transforming, extending it with web services and linking it to databases.


### PR DESCRIPTION
Added Nuts to Miscellaneous (after [Modernizer])

Nuts is a Java package manager. It fills a gap that neither Maven nor JBang addresses: a full package manager 
for the JVM that installs and runs Java applications from Maven Central (or any Maven repository), provisions the required JDK automatically, and manages application lifecycles across platforms — without requiring Java to already be installed.

Unlike JBang (scripting-focused, mostly single-file) or Maven/Gradle (build tool), Nuts is oriented toward end-user application distribution and runtime management, similar in spirit to npm/nvm but native to the Java ecosystem.

* GNU Lesser General Public License v3
* English documentation
* GitHub: https://github.com/thevpc/nuts
* Maven Central: https://central.sonatype.com/artifact/net.thevpc.nuts/nuts




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `Nuts` to the Distribution section of the README as a JVM package manager that installs and runs Java apps from Maven repositories with automatic JDK provisioning. This improves discoverability of tools for end-user app distribution and runtime management.

<sup>Written for commit 66daba6c5efb78acf52114632bef4ff7892af68e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

