### PR TITLE
Add Flat File category (BeanIO, fixedformat4j, Flatpack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We are evaluating to make this the default, you can provide feedback here in [#1
     - [Distribution](#distribution)
     - [Document Processing](#document-processing)
     - [Financial](#financial)
+    - [Flat File](#flat-file)
     - [Formal Verification](#formal-verification)
     - [Functional Programming](#functional-programming)
     - [Game Development](#game-development)
@@ -478,6 +479,14 @@ _Libraries related to the financial domain._
 - [Square](https://github.com/square/connect-java-sdk) - Integration with the Square API.
 - [Stripe](https://github.com/stripe/stripe-java) - Integration with the Stripe API.
 - [ta4j](https://github.com/ta4j/ta4j) - Library for technical analysis.
+
+### Flat File
+
+_Frameworks and libraries for reading and writing fixed-length and delimited flat files._
+
+- [BeanIO](https://github.com/beanio/beanio) - Maps flat files of fixed-length or delimited records to and from Java beans using XML or annotation configuration.
+- [fixedformat4j](https://github.com/jeyben/fixedformat4j) - Annotation-driven mapping of fixed-width flat files to and from POJOs and Java records.
+- [Flatpack](https://github.com/Appendium/flatpack) - Parses and writes delimited and fixed-length flat files with optional column-mapping definitions.
 
 ### Formal Verification
 


### PR DESCRIPTION
## What

Adds a new **Flat File** section grouping three maintained, Apache-2.0 libraries that read and write fixed-length / delimited flat-file records by mapping them to and from Java objects:

- [BeanIO](https://github.com/beanio/beanio)
- [fixedformat4j](https://github.com/jeyben/fixedformat4j)
- [Flatpack](https://github.com/Appendium/flatpack)

## Why a new category

These are flat-file *object-mapping* libraries, not CSV parsers, so they don't fit the existing **CSV** section (the one CSV entry that touches fixed-width, uniVocity-parsers, is primarily a CSV/TSV parser and stays there). Three same-domain libraries that don't fit a pre-existing specialized section is exactly the case contribution rule 4 describes for forming a new specialized section.

Each description states the library's distinguishing approach (annotation vs XML config, fixed-length vs delimited support) per the "unique features" requirement.

## Disclosure

I am the author of **fixedformat4j**. The other two entries (BeanIO, Flatpack) are independent libraries included to populate the category fairly rather than submit a single-entry self-promoting section. All three are Apache-2.0 licensed, documented in English, and not archived.

## Checklist

- [x] Format `[LIBRARY](LINK) - DESCRIPTION.`
- [x] Entries in ascending alphabetical order
- [x] Descriptions end with a period
- [x] TOC updated
- [x] No trailing whitespace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Flat File category in the README to group flat-file object-mapping libraries, listing BeanIO, fixedformat4j, and Flatpack with brief descriptions. Updates the table of contents; CSV section remains unchanged since these are not CSV parsers.

<sup>Written for commit cd7f30e8b03a40f56b18833c878489d69ca1c096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

