### PR TITLE
Add Dokimos to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ _Frameworks and libraries that help implementing and verifying design and archit
 
 _Frameworks that help you to leverage LLMs and AI._
 
+- [Dokimos](https://github.com/dokimos-dev/dokimos) - Evaluation framework for LLM and AI-agent applications that scores responses, validates tool calls and execution traces, and catches quality regressions in CI.
 - [JamJet](https://github.com/jamjet-labs/jamjet) - Agent runtime with a Java SDK for building AI agents, supporting graph-based workflow orchestration, multi-agent coordination, and MCP/A2A protocols.
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Simplifies integration of LLMs with unified APIs and a comprehensive toolbox.
 - [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Enables applications to interact with AI models and tools through a standardized interface (i.e. Model Context Protocol), supporting both synchronous and asynchronous communication patterns.


### PR DESCRIPTION
Adds Dokimos to the Artificial Intelligence section.

The other entries in this category build LLM or agent apps. LangChain4j, JamJet, and the MCP Java SDK all help you create them. Dokimos does the opposite: it tests them. It scores responses, validates tool calls and execution traces, and fails the build on a quality regression, all as a normal JUnit test. It is the only evaluation framework in the category.

Disclosure: I maintain Dokimos. It is MIT licensed and published to Maven Central under dev.dokimos. I think it fills a real gap in this list, since none of the AI entries cover evaluation or regression testing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Dokimos to the Artificial Intelligence section to cover evaluation and regression testing for LLM and agent apps. It scores responses, validates tool calls and execution traces, and catches quality regressions in CI.

<sup>Written for commit 7eeba08e55b5a934361b8c6a7dcfe0aec9d08990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

