### PR TITLE
Update Sheetz description with ODS support and v1.1.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ _Libraries that assist with processing office document formats._
 - [docx4j](https://www.docx4java.org/trac/docx4j) - Create and manipulate Microsoft Open XML files.
 - [fastexcel](https://github.com/dhatim/fastexcel) - High performance library to read and write large Excel (XLSX) worksheets.
 - [jackson-dataformat-spreadsheet](https://github.com/scndry/jackson-dataformat-spreadsheet) - Jackson dataformat module for reading and writing Excel (XLSX/XLS) as POJOs via `ObjectMapper`.
-- [Sheetz](https://github.com/chitralabs/sheetz) - Library for reading and writing Excel and CSV files with annotation-based mapping, streaming support, and built-in validation.
+- [Sheetz](https://github.com/chitralabs/sheetz) - Reads and writes Excel, CSV and ODS files with annotation mapping, streaming, styling and validation.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
 
 ### Financial

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ _Libraries that assist with processing office document formats._
 - [documents4j](https://documents4j.com/#/) - API for document format conversion using third-party converters such as MS Word.
 - [docx4j](https://www.docx4java.org/trac/docx4j) - Create and manipulate Microsoft Open XML files.
 - [fastexcel](https://github.com/dhatim/fastexcel) - High performance library to read and write large Excel (XLSX) worksheets.
-- [Sheetz](https://github.com/chitralabs/sheetz) - Library for reading and writing Excel and CSV files with annotation-based mapping, streaming support, and built-in validation.
+- [Sheetz](https://github.com/chitralabs/sheetz) - One-liner API for reading and writing Excel (XLSX, XLS), CSV, and ODS files with annotation-based mapping, SAX streaming, 19 automatic type converters, cell styling, and built-in validation.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
 
 ### Financial


### PR DESCRIPTION
Sheetz [v1.1.0](https://github.com/chitralabs/sheetz/releases/tag/v1.1.0) added several features that should be reflected in the description:

- **ODS (LibreOffice Calc)** format support — now covers XLSX, XLS, CSV, and ODS
- **Cell styling** via `@Style` annotation
- **19 automatic type converters** (LocalDate, BigDecimal, UUID, Enum, etc.)
- **SAX streaming** for constant-memory processing of large files

Updated the description to accurately represent the current feature set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `Sheetz` entry in README to reflect v1.1.0. It now highlights ODS support and clarifies features: annotation mapping, streaming, styling, and validation.

<sup>Written for commit d5cf30926500edba953009aeff4d30f91f2e2118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

