### PR TITLE
Add GraphCompose to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,7 @@ _Tools to help with PDF files._
 - [DynamicReports](https://github.com/dynamicreports/dynamicreports) - Simplifies JasperReports. (LGPL-3.0-only)
 - [Eclipse BIRT](https://www.eclipse.org/birt) - Report engine for creating PDF and other formats (DOCX, XLSX, HTML, etc) using Eclipse-based visual editor.
 - [flyingsaucer](https://github.com/flyingsaucerproject/flyingsaucer) - XML/XHTML and CSS 2.1 renderer. (LGPL-2.1-or-later)
+- [GraphCompose](https://github.com/DemchaAV/GraphCompose) - Declarative engine for structured business PDFs with semantic layout, atomic pagination, theme tokens, and native vector charts.
 - [iText ![c]](https://itextpdf.com/en) - Creates PDF files programmatically.
 - [JasperReports](https://community.jaspersoft.com/project/jasperreports-library) - Complex reporting engine. (LGPL-3.0-only)
 - [Open HTML to PDF](https://github.com/openhtmltopdf/openhtmltopdf) - Properly supports modern PDF standards based on flyingsaucer and Apache PDFBox.


### PR DESCRIPTION
Adding **GraphCompose** to the **PDF** section.

**What it is:** an open-source (MIT) declarative Java engine for generating structured business PDFs, built on Apache PDFBox.

**How it differs from existing PDF entries** (per the "similar scope → state unique features" rule):
The current PDF entries fall into three groups — low-level toolkits (Apache PDFBox, iText, OpenPDF), template-driven report engines (JasperReports, DynamicReports, Dynamic Jasper, Eclipse BIRT), and HTML/CSS→PDF renderers (flyingsaucer, Open HTML to PDF). GraphCompose is none of these: it is a declarative, component-based document model authored directly in Java, with semantic layout, atomic split-aware pagination, theme tokens, and native vector charts. That approach is not currently represented in the list (unique methodology / niche need).

**License:** MIT — OSI-approved, not GPL/AGPL.
**Maintenance:** actively maintained, with documentation at https://demchaav.github.io/GraphCompose/

Checklist:
- [x] Individual pull request for a single suggestion
- [x] Added in alphabetical order (between flyingsaucer and iText)
- [x] Concise, unbiased description ending with a period
- [x] Searched for duplicates — none
- [x] OSI-licensed, not GPL/AGPL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `GraphCompose` to the PDF tools list in README. It’s a declarative Java engine (MIT) for structured business PDFs with semantic layout, split-aware pagination, theme tokens, and native vector charts.

<sup>Written for commit 5308801f37217d13f1321e460e8554c61aeab64f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

