### PR TITLE
add jquick-pdf to PDF section

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ _Tools to help with PDF files._
 - [Open HTML to PDF](https://github.com/openhtmltopdf/openhtmltopdf) - Properly supports modern PDF standards based on flyingsaucer and Apache PDFBox.
 - [OpenPDF](https://github.com/LibrePDF/OpenPDF) - Open-source iText fork. (LGPL-3.0-only & MPL-2.0)
 - [Tabula](https://github.com/tabulapdf/tabula-java) - Extracts tables from PDF files.
-
+- [jquick-pdf](https://github.com/paohaijiao/jquick-pdf) - A lightweight Java library for generating PDFs from HTML-like templates and ECharts graphics without any browser dependency.
 ### Performance analysis
 
 _Tools for performance analysis, profiling and benchmarking._

--- a/README.md
+++ b/README.md
@@ -955,10 +955,11 @@ _Tools to help with PDF files._
 - [GraphCompose](https://github.com/DemchaAV/GraphCompose) - Declarative engine for structured business PDFs with semantic layout, atomic pagination, theme tokens, and native vector charts.
 - [iText ![c]](https://itextpdf.com/en) - Creates PDF files programmatically.
 - [JasperReports](https://community.jaspersoft.com/project/jasperreports-library) - Complex reporting engine. (LGPL-3.0-only)
+- [jquick-pdf](https://github.com/paohaijiao/jquick-pdf) - Generates PDFs from HTML-like templates and ECharts-style charts using iText 7, without a browser dependency.
 - [Open HTML to PDF](https://github.com/openhtmltopdf/openhtmltopdf) - Properly supports modern PDF standards based on flyingsaucer and Apache PDFBox.
 - [OpenPDF](https://github.com/LibrePDF/OpenPDF) - Open-source iText fork. (LGPL-3.0-only & MPL-2.0)
 - [Tabula](https://github.com/tabulapdf/tabula-java) - Extracts tables from PDF files.
-- [jquick-pdf](https://github.com/paohaijiao/jquick-pdf) - A lightweight Java library for generating PDFs from HTML-like templates and ECharts graphics without any browser dependency.
+
 ### Performance analysis
 
 _Tools for performance analysis, profiling and benchmarking._


### PR DESCRIPTION
## Project Info
- **Name**: jquick-pdf
- **URL**: https://github.com/paohaijiao/jquick-pdf
- **Category**: PDF
---
## Rationale
Unlike most Java PDF libraries that depend on headless browsers or native rendering engines, jquick-pdf is a pure Java implementation with zero external dependencies. It provides native support for rendering 30+ ECharts-style charts (bar, line, pie, radar, heatmap, treemap, etc.) directly within PDFs, which is currently uncommon in the Java ecosystem.
This makes it particularly suitable for generating data-rich reports in enterprise applications where deployment simplicity and charting capabilities are both required.

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `jquick-pdf` to the README PDF tools list, noting it generates PDFs from HTML-like templates and ECharts-style charts using `iText 7` without a browser dependency.

<sup>Written for commit 7fe5943a04512b6153c1441b77d495f60a6c7557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

