### PR TITLE
Add HashSmith to Data Structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ _Efficient and specific data structures._
 - [Apache Parquet](https://parquet.apache.org) - Columnar storage format based on assembly algorithms from Google's paper on Dremel.
 - [Apache Thrift](https://thrift.apache.org) - Data interchange format that originated at Facebook.
 - [Big Queue](https://github.com/bulldog2011/bigqueue) - Fast and persistent queue based on memory-mapped files.
+- [HashSmith](https://github.com/bluuewhale/hash-smith) - Hash map and set implementations using SwissTable-style SWAR/SIMD control-byte probing, optimized for memory efficiency.
 - [Persistent Collection](https://github.com/hrldcpr/pcollections) - Persistent and immutable analogue of the Java Collections Framework.
 - [Protobuf](https://github.com/protocolbuffers/protobuf) - Google's data interchange format.
 - [RoaringBitmap](https://github.com/RoaringBitmap/RoaringBitmap) - Fast and efficient compressed bitmap.


### PR DESCRIPTION
Adds HashSmith under Data Structures.

HashSmith provides high-performance hash table implementations for the JVM (SwissMap, SwissSimdMap, ConcurrentSwissMap, SwissSet) that implement the standard `java.util` Map/Set interfaces.

**Why it fits the list**
- Unique approach (criterion c): SwissTable-inspired control-byte probing using SWAR by default, with an optional SIMD variant built on the incubating Vector API.
- Distinguishing feature vs. other Data Structures entries: unlike the interchange formats and persistent/immutable collections already listed, HashSmith is a drop-in, mutable Map/Set focused on lower per-entry memory overhead than the built-in JDK `HashMap`.

**Project details**
- License: MIT (open source library, compatible with the contribution guidelines).
- JDK 21+, published to Maven Central (`io.github.bluuewhale:hashsmith`).
- English documentation, JMH benchmarks, and Apache Commons / Guava compatibility test suites.

_Disclosure: I am the author of this project._

**Checklist**
- [x] Individual PR for a single suggestion
- [x] Format: `[LIBRARY](LINK) - DESCRIPTION.`
- [x] Sorted in ascending alphabetical order
- [x] Description is short and ends with a period


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add HashSmith to the Data Structures list in README to highlight a JVM library for memory‑efficient hash maps and sets.

The entry describes SwissTable‑style SWAR/SIMD control‑byte probing and positions HashSmith as a drop‑in mutable `Map`/`Set` option.

<sup>Written for commit ba34c768ae3ac39b0cc046c64597d9e41b5881f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

