### PR TITLE
Add sklearn-java to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,13 +742,13 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [DJL](https://djl.ai) - High-level and engine-agnostic framework for deep learning.
 - [H2O ![c]](https://www.h2o.ai) - Analytics engine for statistics over big data.
 - [Intelligent java](https://github.com/Barqawiz/IntelliJava) - Seamlessly integrate with remote deep learning and language models programmatically.
-- [JSAT](https://github.com/EdwardRaff/JSAT)
-- [sklearn-java](https://github.com/kVeyra/sklearn-java) - Pure Java reimplementation of scikit-learn's machine learning API with 1e-8 numerical accuracy. - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
+- [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
 - [m2cgen](https://github.com/BayesWitnesses/m2cgen) - CLI tool to transpile models into native code.
 - [Neureka](https://github.com/Gleethos/neureka) - A lightweight, platform independent, OpenCL accelerated nd-array/tensor library.
 - [oj! Algorithms](https://www.ojalgo.org/) - High-performance mathematics, linear algebra and optimisation needed for data science, machine learning and scientific computing.
 - [Oryx 2](https://github.com/OryxProject/oryx) - Framework for building real-time, large-scale machine learning applications. Includes end-to-end applications for collaborative filtering, classification, regression, and clustering.
 - [Siddhi](https://github.com/siddhi-io/siddhi) - Cloud native streaming and complex event processing engine.
+- [sklearn-java](https://github.com/kVeyra/sklearn-java) - Implements scikit-learn-style machine learning algorithms in pure Java.
 - [Smile](https://github.com/haifengl/smile) - Statistical Machine Intelligence and Learning Engine provides a set of machine learning algorithms and a visualization library.
 - [Tribuo](https://tribuo.org/) - Provides tools for classification, regression, clustering, model development and interfaces with other libraries such as scikit-learn, pytorch and TensorFlow.
 - [Weka](https://www.cs.waikato.ac.nz/ml/weka/) - Collection of algorithms for data mining tasks ranging from pre-processing to visualization. (GPL-3.0-only)

--- a/README.md
+++ b/README.md
@@ -738,7 +738,8 @@ _Tools that provide specific statistical algorithms for learning from data._
 - [DJL](https://djl.ai) - High-level and engine-agnostic framework for deep learning.
 - [H2O ![c]](https://www.h2o.ai) - Analytics engine for statistics over big data.
 - [Intelligent java](https://github.com/Barqawiz/IntelliJava) - Seamlessly integrate with remote deep learning and language models programmatically.
-- [JSAT](https://github.com/EdwardRaff/JSAT) - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
+- [JSAT](https://github.com/EdwardRaff/JSAT)
+- [sklearn-java](https://github.com/kVeyra/sklearn-java) - Pure Java reimplementation of scikit-learn's machine learning API with 1e-8 numerical accuracy. - Algorithms for pre-processing, classification, regression, and clustering with support for multi-threaded execution. (GPL-3.0-only)
 - [m2cgen](https://github.com/BayesWitnesses/m2cgen) - CLI tool to transpile models into native code.
 - [Neureka](https://github.com/Gleethos/neureka) - A lightweight, platform independent, OpenCL accelerated nd-array/tensor library.
 - [oj! Algorithms](https://www.ojalgo.org/) - High-performance mathematics, linear algebra and optimisation needed for data science, machine learning and scientific computing.


### PR DESCRIPTION
## Description

Adds [sklearn-java](https://github.com/kVeyra/sklearn-java) to the Machine Learning section — a pure Java reimplementation of scikit-learn's API.

- Apache 2.0 license
- 72+ sklearn algorithms implemented (linear models, trees, ensembles, SVM, preprocessing, metrics, model selection, clustering, naive bayes, neighbors)
- API mirrors sklearn exactly: .fit(), .predict(), .transform(), .score()
- 190+ JUnit 5 tests passing
- Numerical accuracy validated against Python sklearn to 1e-8

Let me know if any changes are needed!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `sklearn-java` to the Machine Learning section and fixed the entry text. Pure Java reimplementation of scikit-learn’s API.

<sup>Written for commit d7d9ded96371eff2678a8cf795e9fdbfe68a3d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

