### PR TITLE
Add Actual Schema Gradle Plugin to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ _Efficient and specific data structures._
 
 _Everything that simplifies interactions with the database._
 
+- [Actual Schema Gradle Plugin](https://github.com/YRashid/actual-schema-gradle-plugin) - Generates PostgreSQL schema DDL from Liquibase migrations using Testcontainers.
 - [Apache Calcite](https://calcite.apache.org) - Dynamic data management framework. It contains many of the pieces that comprise a typical database management system.
 - [Apache Drill](https://drill.apache.org) - Distributed, schema on-the-fly, ANSI SQL query engine for Big Data exploration.
 - [Apache Phoenix](https://phoenix.apache.org) - High-performance relational database layer over HBase for low-latency applications.
@@ -385,7 +386,6 @@ _Everything that simplifies interactions with the database._
 - [Xodus](https://github.com/JetBrains/xodus) - Highly concurrent transactional schema-less and ACID-compliant embedded database.
 - [CosId](https://github.com/Ahoo-Wang/CosId) - Universal, flexible, high-performance distributed ID generator.
 - [Apache ShardingSphere](https://github.com/apache/shardingsphere) - Distributed SQL transaction & query engine that allows for data sharding, scaling, encryption, and more on any database.
-- [Actual Schema Gradle Plugin](https://github.com/YRashid/actual-schema-gradle-plugin) - Gradle plugin that generates a PostgreSQL schema DDL from Liquibase migrations using Testcontainers.
 
 ### Date and Time
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ _Everything that simplifies interactions with the database._
 - [Xodus](https://github.com/JetBrains/xodus) - Highly concurrent transactional schema-less and ACID-compliant embedded database.
 - [CosId](https://github.com/Ahoo-Wang/CosId) - Universal, flexible, high-performance distributed ID generator.
 - [Apache ShardingSphere](https://github.com/apache/shardingsphere) - Distributed SQL transaction & query engine that allows for data sharding, scaling, encryption, and more on any database.
+- [Actual Schema Gradle Plugin](https://github.com/YRashid/actual-schema-gradle-plugin) - Gradle plugin that generates a PostgreSQL schema DDL from Liquibase migrations using Testcontainers.
 
 ### Date and Time
 


### PR DESCRIPTION
Adds Actual Schema Gradle Plugin to the Database section.

The plugin fills a niche between Liquibase and schema documentation tools: it applies Liquibase migrations to a temporary PostgreSQL database via Testcontainers and exports the resulting schema.sql/DDL. This lets teams keep the actual final database schema in Git and review schema changes in pull requests or CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Actual Schema Gradle Plugin` to the Database section to highlight a Gradle plugin that generates PostgreSQL schema DDL from Liquibase migrations using Testcontainers. Also fixes the entry.

<sup>Written for commit 536ec09737dd05dbd169140ee9e8a14f9317ca3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

