### PR TITLE
Add OfficeFloor to REST Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ _Frameworks specifically for creating RESTful services._
 - [Elide](https://elide.io) - Opinionated framework for JSON- or GraphQL-APIs based on a JPA data model.
 - [Jersey](https://jersey.github.io) - JAX-RS reference implementation.
 - [Microserver](https://github.com/aol/micro-server) - Convenient, extensible microservices plugin system for Spring & Spring Boot. With more than 30 plugins and growing, it supports both micro-monolith and pure microservices styles.
+- [OfficeFloor](https://github.com/officefloor/OfficeFloor) - Spring Boot add-on that adds explicit function orchestration to REST endpoints, with each endpoint's steps, branches and error flows in one YAML file whose directory path maps to the URL.
 - [Rapidoid](https://www.rapidoid.org) - Simple, secure and extremely fast framework consisting of an embedded HTTP server, GUI components and dependency injection.
 - [rest.li](https://github.com/linkedin/rest.li) - Framework for building robust, scalable RESTful architectures using typesafe bindings and asynchronous, non-blocking IO with an end-to-end developer workflow that promotes clean practices, uniform interface design and consistent data modeling.
 - [RESTEasy](https://resteasy.github.io) - Fully certified and portable implementation of the JAX-RS specification.


### PR DESCRIPTION
This adds OfficeFloor under REST Frameworks.

Disclosure: I'm the author of OfficeFloor, so this is a self-submission. I've tried to justify it against the contribution criteria below rather than on my own opinion of the project.

What it is: a Spring Boot add-on that makes each REST endpoint's function orchestration explicit. An endpoint's steps, conditional branches and error flows are declared in a single YAML file, and the file's directory path mirrors the URL (officefloor/rest/greeting/{name}.GET.yml maps to GET /greeting/{name}).

Why it qualifies? Criterion (c), a unique approach: OfficeFloor is built on a distinct paradigm, Inversion of Coupling Control, which separates three concerns most frameworks conflate: Continuation Injection (orchestrating functions), Thread Injection (assigning threads to functions), and Dependency Injection (injecting state). The approach is documented in a peer-reviewed paper and an introductory article:

-  Paper: [OfficeFloor: using office patterns to improve software design (ACM)](http://dl.acm.org/authorize?N05689)
-  Article: [Inversion of Coupling Control](https://blog.officefloor.net/2019/02/inversion-of-coupling-control.html)

What distinguishes it from other entries in the section: the other REST Frameworks listed handle routing and binding through annotations or code, where an endpoint's flow is implicit in the call stack. OfficeFloor's differentiator is that the orchestration is explicit and external.  One readable YAML file per endpoint, with the directory layout acting as a direct index from URL to the code involved. I'm not aware of another entry in the section that takes this approach.

Why the pattern is timely: this explicit structure has also become more practically relevant with AI-assisted development. Because routes are enumerable by listing a directory and each endpoint's flow and classes are named in one file, tools can navigate from a URL straight to the relevant code without parsing scattered annotations. I mention this only as context; the novelty above stands on its own.


Compliance:

- Added in ascending alphabetical order (between Microserver and Rapidoid).
- Format [NAME](LINK) - DESCRIPTION., single sentence, ends with a period.
- Single pull request for this one suggestion.
- Open source under the Apache License 2.0; documentation in English.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OfficeFloor to the REST Frameworks list in README. It’s a Spring Boot add-on that makes each endpoint’s flow explicit in one YAML file whose directory path maps to the URL.

<sup>Written for commit 6b01ff4536b90671d602fde13ff2d1032d38a952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

