### PR TITLE
Add AISmessages to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ _Tools for creating and managing microservices._
 
 _Everything else._
 
+- [AISmessages](https://github.com/tbsalling/aismessages) - Decoder of NMEA-armoured AIS messages used in maritime navigation and safety systems, offering ITU 1371 compliance, high performance and zero runtime dependencies. (CC-BY-NC-SA-4.0)
 - [CQEngine](https://github.com/npgall/cqengine) - Ultra-fast, SQL-like queries on Java collections.
 - [Design Patterns](https://github.com/iluwatar/java-design-patterns) - Implementation and explanation of the most common design patterns.
 - [FF4J](https://github.com/ff4j/ff4j) - Feature Flags for Java.

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ _Tools for creating and managing microservices._
 
 _Everything else._
 
-- [AISmessages](https://github.com/tbsalling/aismessages) - Decoder of NMEA-armoured AIS messages used in maritime navigation and safety systems, offering ITU 1371 compliance, high performance and zero runtime dependencies. (CC-BY-NC-SA-4.0)
+- [AISmessages](https://github.com/tbsalling/aismessages) - Decodes NMEA-armoured AIS messages for maritime navigation and safety systems with ITU-R M.1371 support and no runtime dependencies. (CC-BY-NC-SA-4.0)
 - [CQEngine](https://github.com/npgall/cqengine) - Ultra-fast, SQL-like queries on Java collections.
 - [Design Patterns](https://github.com/iluwatar/java-design-patterns) - Implementation and explanation of the most common design patterns.
 - [FF4J](https://github.com/ff4j/ff4j) - Feature Flags for Java.


### PR DESCRIPTION
Adds [AISmessages](https://github.com/tbsalling/aismessages) to the **Miscellaneous** section.

AISmessages decodes NMEA-armoured AIS messages used in maritime navigation and safety systems.
  
**Why it fits the list (fills a gap — criterion d):** there is currently no Java AIS/maritime-messaging library on the list.
  
**Unique selling points:**
  - ITU-R M.1371 compliant across the standard AIS message types.
  - High decoding throughput with a low per-message memory footprint.
  - Zero runtime dependencies.
  
**Placement:** Filed under Miscellaneous per rule 3, as it doesn't fit an existing specialized section and is a single entry (rule 4 reserves new sections for two or more same-domain entries). Inserted in alphabetical order and the description ends with a full stop.
  
**License note:** AISmessages is free for non-commercial use, licensed under CC-BY-NC-SA-4.0. This isn't on the OSI list, so flagging it explicitly against criterion (ii); the entry is marked `(CC-BY-NC-SA-4.0)` for transparency. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `AISmessages` to the Miscellaneous list as a Java decoder for NMEA-armoured AIS messages used in maritime navigation and safety systems. The entry specifies ITU‑R M.1371 support, no runtime dependencies, and its CC‑BY‑NC‑SA‑4.0 license.

<sup>Written for commit 249bb7bc8b61116b28ac5ab5ca349365a0349da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

