### PR TITLE
Add Hexana plugin to JVM tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ _Tools for performance analysis, profiling and benchmarking._
 - [LatencyUtils](https://github.com/LatencyUtils/LatencyUtils) - Utilities for latency measurement and reporting.
 - [JVM Hotpath](https://github.com/sfkamath/jvm-hotpath) - Java agent for line-level execution frequency analysis to identify algorithmic bottlenecks.
 - [Argus](https://github.com/rlaope/Argus) - JVM diagnostics CLI for jcmd, JFR, async-profiler, heap analysis and machine-readable health verdicts.
+- [Hexana](https://hexana.lovable.app/?utm_source=awesome_jvm&utm_medium=referral&utm_campaign=landing_spread_q3) - IntelliJ plugin for JIT analysis: captures C2 and GraalVM JIT emission via a JVMTI agent (.jit files), visualizes compiled methods with inlining trees, and auto-attaches to JMH forks for benchmark-level inspection.
 
 ### Platform
 


### PR DESCRIPTION
Adds Hexana under Performance analysis.

Hexana is an IntelliJ plugin (JetBrains InnoHub project) for inspecting
JIT-compiled code. Unlike JITWatch, it captures nmethods directly through
a bundled JVMTI agent — no -XX:+LogCompilation parsing and no hsdis
install — and can auto-attach to every forked JMH benchmark JVM, writing
one .jit dump per benchmark.

Free, no signup. Docs: https://jetbrains.github.io/hexana


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Hexana to the Performance analysis tools list in the README. It’s an IntelliJ plugin that captures C2/GraalVM JIT output via a bundled JVMTI agent and can auto-attach to JMH forks for per-benchmark .jit dumps.

<sup>Written for commit 24ea7ac7bfe824a1e164d6738cacd9d50f90f429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

