### PR TITLE
Add Viglet Turing ES to Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,7 @@ _Engines that index documents for search and analysis._
 - [Apache Solr](https://lucene.apache.org/solr/) - Enterprise search engine optimized for high-volume traffic.
 - [Elasticsearch](https://www.elastic.co) - Distributed, multitenant-capable, full-text search engine with a RESTful web interface and schema-free JSON documents.
 - [Indexer4j](https://github.com/haeungun/indexer4j) - Simple and light full text indexing and searching library.
+- [Viglet Turing ES](https://github.com/openviglet/turing-ce) - Enterprise search platform (not a library): layers faceted, semantic and hybrid search, RAG and AI agents over a pluggable Apache Solr/Elasticsearch/Lucene backend.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ _Engines that index documents for search and analysis._
 - [Apache Solr](https://lucene.apache.org/solr/) - Enterprise search engine optimized for high-volume traffic.
 - [Elasticsearch](https://www.elastic.co) - Distributed, multitenant-capable, full-text search engine with a RESTful web interface and schema-free JSON documents.
 - [Indexer4j](https://github.com/haeungun/indexer4j) - Simple and light full text indexing and searching library.
-- [Viglet Turing ES](https://github.com/openviglet/turing-ce) - Enterprise search platform (not a library): layers faceted, semantic and hybrid search, RAG and AI agents over a pluggable Apache Solr/Elasticsearch/Lucene backend.
+- [Viglet Turing ES](https://github.com/openviglet/turing-ce) - Self-hosted enterprise search platform with faceted, semantic and hybrid search, RAG, AI agents and pluggable Solr, Elasticsearch or Lucene backends.
 
 ### Security
 


### PR DESCRIPTION
Adding **Viglet Turing ES** to the Search section.

- Repo: https://github.com/openviglet/turing-ce
- License: Apache-2.0 (OSI-approved)
- Docs in English: https://openviglet.github.io / http://viglet.org/turing

**Why it's distinct from the existing entries (Lucene/Solr/Elasticsearch):** those are search *libraries/engines*. Turing ES is a full enterprise-search *platform/application* built on Spring Boot that runs on top of a pluggable Solr/Elasticsearch/Lucene backend and adds faceted + semantic + hybrid (RRF) search, RAG, and AI agents. It fills the application-layer gap in this category.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Viglet Turing ES` to the Search section as a self-hosted enterprise search platform (application layer). It provides faceted, semantic, and hybrid (RRF) search, RAG, and AI agents, running on pluggable Solr, Elasticsearch, or Lucene backends.

<sup>Written for commit 5e135647bfde2f8e54a54bb15bce6dcd92bf80e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

