### PR TITLE
Add Spotless to formatting tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ _Tools that format or restructure Java source code._
 - [google-java-format](https://github.com/google/google-java-format) - Reformats Java source code to follow Google Java Style.
 - [JHarmonizer](https://github.com/lemon-ant/JHarmonizer) - Safely reorders Java source code with configurable rules and Palantir Java Format.
 - [Palantir Java Format](https://github.com/palantir/palantir-java-format) - Formatter based on google-java-format with wider lines and lambda-friendly output.
+- [Spotless](https://github.com/diffplug/spotless) - Spotless can format/enforce multiple code styles including Palantir & Google for multiple languages using Gradle or Maven plugins.
 
 ### Code Generators
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ _Tools that format or restructure Java source code._
 - [google-java-format](https://github.com/google/google-java-format) - Reformats Java source code to follow Google Java Style.
 - [JHarmonizer](https://github.com/lemon-ant/JHarmonizer) - Safely reorders Java source code with configurable rules and Palantir Java Format.
 - [Palantir Java Format](https://github.com/palantir/palantir-java-format) - Formatter based on google-java-format with wider lines and lambda-friendly output.
-- [Spotless](https://github.com/diffplug/spotless) - Spotless can format/enforce multiple code styles including Palantir & Google for multiple languages using Gradle or Maven plugins.
+- [Spotless](https://github.com/diffplug/spotless) - A versatile code formatter for Gradle and Maven that enforces multiple styles (including Google and Palantir) across Java and other languages.
 
 ### Code Generators
 


### PR DESCRIPTION
Spotless is the go to tooling for formatting and enforcement of a code style. Its flexibility, support for multiple build tool chains and as a tool for enforcing styles mentioned above it makes it a worthwhile addition.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `Spotless` to the formatting tools list in the README and clarified its description. It’s a versatile formatter for Gradle and Maven that enforces Google and Palantir styles and supports Java and other languages.

<sup>Written for commit 7e702e70143f99c28f28cb2415542550bfb592a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

