### PR TITLE
Add JSpecify to static analysis tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ _Tools that provide metrics and quality measurements._
 - [Error Prone Support](https://github.com/PicnicSupermarket/error-prone-support) - Error Prone extensions: extra bug checkers and a large battery of Refaster templates.
 - [Infer](https://github.com/facebook/infer) - Modern static analysis tool for verifying the correctness of code.
 - [jQAssistant](https://jqassistant.org) - Static code analysis with Neo4J-based query language. (GPL-3.0-only)
+- [JSpecify](https://jspecify.dev/) - Standardized nullness annotations designed to work uniformly across various Java IDEs, compilers, and static analysis tools.
 - [NullAway](https://github.com/uber/NullAway) - Eliminates NullPointerExceptions with low build-time overhead.
 - [PMD](https://github.com/pmd/pmd) - Source code analysis for finding bad coding practices.
 - [p3c](https://github.com/alibaba/p3c) - Provides Alibaba's coding guidelines for PMD, IDEA and Eclipse.


### PR DESCRIPTION
Add JSpecify to the README, highlighting its role in providing standardized nullness annotations. JSpecify aims to create a unified framework for null-safety that works uniformly across various Java IDEs, compilers, and static analysis tools.

This addition serves as a valuable resource for developers looking to implement robust, tool-agnostic null checking in modern Java projects.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `JSpecify` to the static analysis tools list in the README to surface standardized nullness annotations that work across Java IDEs, compilers, and tools. This helps developers find a tool-agnostic approach to null-safety in Java.

<sup>Written for commit b7cd578d5ac41b019d635b7100b54bde94db32b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

