### PR TITLE
Add jquick-excel: declarative XML DSL for Excel import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ _Libraries that assist with processing office document formats._
 - [Sheetz](https://github.com/chitralabs/sheetz) - Reads and writes Excel, CSV and ODS files with annotation mapping, streaming, styling and validation.
 - [xberg](https://github.com/xberg-io/xberg) - Extracts text, tables and metadata from PDFs, Office documents, images and other formats through a Java binding.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
-
+- [Jquick Excel](https://github.com/paohaijiao/jquick-excel) - A lightweight Java Excel framework that uses declarative XML configuration for import/export. Supports 20+ validation rules, 50+ formulas, and 10 chart types with a simple DSL
 ### Financial
 
 _Libraries related to the financial domain._


### PR DESCRIPTION
Adds Jquick Excel to the Excel section.

What makes it different from other Excel libraries is the XML DSL approach. Most existing solutions either force you to write tons of POI code or rely on annotations that require recompilation when rules change. This one puts all the mapping, validation rules, formulas, and styling into XML files, so you can tweak the import/export logic without touching Java code.

It supports 20+ validation rules (email, mobile, regex, range, dictionary lookup), 50+ formulas, and 10 chart types. The project is actively maintained with several releases out already, and the documentation is available in both English and Chinese.

Not a commercial project, just a solid open-source tool that fills a gap in the Excel processing space.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `jquick-excel` to the Excel libraries list in `README_SOURCE.md`, describing its declarative XML DSL for configuring import, export, validation, formulas, and charts.

<sup>Written for commit 8d41e607316b0e9d796853312935529ed90dbcda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

