### PR TITLE
Add Bastillion to security libraries list

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -1025,6 +1025,7 @@ _Libraries that handle security, authentication, authorization or session manage
 
 - [Apache Shiro](https://github.com/apache/shiro) - Performs authentication, authorization, cryptography and session management.
 - [Ayza](https://github.com/Hakky54/ayza) - High-level SSL configuration builder for configuring HTTP clients and servers with SSL/TLS.
+- [Bastillion](https://github.com/bastillion-io/Bastillion) - Self-hosted SSH gateway with centralized SSH key management, web-based terminal, and session audit/replay; source-available under the Prosperity License.
 - [Bouncy Castle](https://github.com/bcgit/bc-java) - All-purpose cryptographic library and JCA provider offering a wide range of functions, from basic helpers to PGP/SMIME operations.
 - [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - CLI tool and library for extracting and exporting server certificates from HTTPS endpoints.
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track) - Software composition analysis platform for identifying supply-chain risk.


### PR DESCRIPTION
Added Bastillion to the list of security libraries.

## Suggestion type

- [x] Project
- [ ] Resource

## Checklist

- [x] I searched the list and existing issues for duplicates.
- [x] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x] This pull request contains one suggestion.
- [x] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x] I used the canonical project or resource link.
- [x] The suggestion is current and maintained.
- [x] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x] Licensing is clear and any restrictive terms are disclosed where applicable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Bastillion to the Security libraries list in `README_SOURCE.md`. It’s described as a self-hosted SSH gateway with centralized key management, web terminal, session audit/replay, and its Prosperity License noted.

<sup>Written for commit e1ea2aca8c1903b1a05d24c2a398fbc8e018d6a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

