### PR TITLE
add jquick-sql to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ _Libraries that assist with processing office document formats._
 - [Sheetz](https://github.com/chitralabs/sheetz) - Reads and writes Excel, CSV and ODS files with annotation mapping, streaming, styling and validation.
 - [xberg](https://github.com/xberg-io/xberg) - Extracts text, tables and metadata from PDFs, Office documents, images and other formats through a Java binding.
 - [zerocell](https://github.com/creditdatamw/zerocell) - Annotation-based API for reading data from Excel sheets into POJOs with focus on reduced overhead.
-
+- [Jquick Excel](https://github.com/paohaijiao/jquick-excel) - A lightweight Java Excel framework that uses declarative XML configuration for import/export. Supports 20+ validation rules, 50+ formulas, and 10 chart types with a simple DSL
 ### Financial
 
 _Libraries related to the financial domain._

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ _Everything that simplifies interactions with the database._
 
 > **[Flyway](https://github.com/flyway/flyway)** <kbd>★ 10.0k</kbd> <kbd>Apache-2.0</kbd> 🟢<br>Simple database migration tool.
 
+> **[JQuick SQL](https://github.com/paohaijiao/jquick-sql)** <kbd>★ 288</kbd> <kbd>Apache-2.0</kbd> 🟢<br>Embeddable, lightweight distributed SQL engine featuring heterogeneous federated query support for unified data access across disparate systems.
+
 > **[H2](https://github.com/h2database/h2database)** <kbd>★ 4.6k</kbd> 🟢<br>Small SQL database notable for its in-memory functionality.
 
 > **[HikariCP](https://github.com/brettwooldridge/HikariCP)** <kbd>★ 21.2k</kbd> <kbd>Apache-2.0</kbd> 🟢<br>High-performance JDBC connection pool.

--- a/README.md
+++ b/README.md
@@ -501,8 +501,6 @@ _Everything that simplifies interactions with the database._
 
 > **[Flyway](https://github.com/flyway/flyway)** <kbd>★ 10.0k</kbd> <kbd>Apache-2.0</kbd> 🟢<br>Simple database migration tool.
 
-> **[JQuick SQL](https://github.com/paohaijiao/jquick-sql)** <kbd>★ 288</kbd> <kbd>Apache-2.0</kbd> 🟢<br>Embeddable, lightweight distributed SQL engine featuring heterogeneous federated query support for unified data access across disparate systems.
-
 > **[H2](https://github.com/h2database/h2database)** <kbd>★ 4.6k</kbd> 🟢<br>Small SQL database notable for its in-memory functionality.
 
 > **[HikariCP](https://github.com/brettwooldridge/HikariCP)** <kbd>★ 21.2k</kbd> <kbd>Apache-2.0</kbd> 🟢<br>High-performance JDBC connection pool.

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -289,6 +289,7 @@ _Everything that simplifies interactions with the database._
 - [eXist](https://github.com/eXist-db/exist) - NoSQL document database and application platform.
 - [FlexyPool](https://github.com/vladmihalcea/flexy-pool) - Brings metrics and failover strategies to the most common connection pooling solutions.
 - [Flyway](https://github.com/flyway/flyway) - Simple database migration tool.
+- [JQuick SQL](https://github.com/paohaijiao/jquick-sql) - Embeddable, lightweight distributed SQL engine featuring heterogeneous federated query support for unified data access across disparate systems.
 - [H2](https://github.com/h2database/h2database) - Small SQL database notable for its in-memory functionality.
 - [HikariCP](https://github.com/brettwooldridge/HikariCP) - High-performance JDBC connection pool.
 - [HSQLDB](https://hsqldb.org/) - HyperSQL 100% Java database.


### PR DESCRIPTION
## Why this belongs in awesome-java

This project fills a distinct gap in the Java ecosystem:

- **Unique value:** Unlike traditional ORM tools or single-database connectors, jquick-sql provides a lightweight, embeddable federated query engine that can query across heterogeneous data sources (RDBMS, files, REST APIs) using standard SQL.
- **Innovative approach:** Implements a Coordinator-Worker architecture with optimizations including predicate pushdown, join reorder, and two-phase aggregation, making distributed query execution accessible with minimal overhead.
- **Active maintenance:** Project is actively maintained with regular updates and clear documentation.

## Additional context

- License: Apache 2.0
- Project is open-source with clear contribution guidelines
- Demonstrates comprehensive SQL feature support including JOINs, subqueries, aggregations, and set operations (UNION/INTERSECT/MINUS)


