### PR TITLE
Add SpringBoot Generator to Code Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ _Tools that generate patterns for repetitive code in order to reduce verbosity a
 
 > **[Spring CRUD Generator](https://github.com/mzivkovicdev/spring-crud-generator)** <kbd>★ 38</kbd> <kbd>Apache-2.0</kbd> 🟢<br>Maven plugin for generating Spring Boot CRUD applications from YAML/JSON specifications.
 
+> **[SpringBoot Generator ![c]](https://www.springboot-generator.com)** - Browser-based generator for Spring Boot CRUD REST APIs from a visual schema, producing the backend and an optional Angular or React frontend as separately deployable projects, with n-ary association entities.
+
 > **[Telosys](https://www.telosys.org/)** <kbd>★ 212</kbd> <kbd>LGPL-3.0</kbd> 🟠<br>Java code-generation toolkit with a CLI and model-driven template engine.
 
 </details>


### PR DESCRIPTION
Adds SpringBoot Generator to Code Generators.

Disclosure: I am the author of this tool.

**Why it qualifies (criterion d — a niche product filling a gap):** it generates the backend and the optional frontend as two separately deployable projects, and it generates n-ary association entities (join entities carrying three or more foreign
keys) directly from the visual schema.

**Distinction from similar entries already listed:**

- **Bootify** — broader than this tool in several areas (more databases, Kotlin, Spring Security, Flyway/Liquibase, modularization). Two concrete differences: Bootify embeds the generated Angular app inside the Spring application as a single artifact, whereas this tool emits backend and frontend as independent projects; and n-ary association entities are generated here rather than modelled by hand.
- **JHipster** — a CLI/Yeoman generator requiring a local Node toolchain and a JDL file. This tool is browser-based with no installation and no CLI.

**Developer-friendliness requirements:**

- Commercial, marked `![c]`. Pricing is public at https://www.springboot-generator.com/pricing
- Free tier: project generation is free and requires no account, and covers MySQL, Java 21, Maven or Gradle, and the complete CRUD REST backend. Paid credits unlock the optional extras (PostgreSQL, Java 17 and 25, generated unit and integration tests, Docker, Swagger, Javadoc, logging, dev/prod profiles, the Angular or React frontend, and n-ary associations beyond two foreign keys).
- Closed source, so there is no license to disclose for source code. The generated projects belong to the user.
- Documentation is in English.

Entry is alphabetically sorted and follows the required format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SpringBoot Generator to the Code Generators list. It's a browser-based Spring Boot CRUD API generator that outputs a separate backend plus optional Angular/React frontend and supports n-ary association entities.

The entry is added to `README_SOURCE.md` since `README.md` is generated from it, and it no longer uses a manual commercial badge per `CONTRIBUTING.md`.

<sup>Written for commit fb7d68fc35f11905ece8a9d2e035f559fdc31544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

