### PR TITLE
Add WireDoctor to Architecture section

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -19,7 +19,7 @@ _Frameworks and libraries that help implementing and verifying design and archit
 - [jMolecules](https://github.com/xmolecules/jmolecules) - Annotations and interfaces to express design and architecture concepts in code.
 - [jQAssistant](https://github.com/jQAssistant/jqassistant) - Static code analysis with Neo4J-based query language.
 - [Taikai](https://github.com/enofex/taikai) - ArchUnit extension with predefined architecture rules for common Java technologies.
-- [WireDoctor](https://github.com/ddsha441981/wiredoctor) - Zero-intrusion Spring Boot runtime diagnostic for cyclic dependencies, slow beans, and ghost detection with interactive physics-based HTML dashboard and CI regression gates.
+- [WireDoctor](https://github.com/ddsha441981/wiredoctor) - Runtime diagnostic for Spring Boot apps that detects cyclic bean dependencies and slow beans, with CI regression gates.
 
 ### Artificial Intelligence
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -19,6 +19,7 @@ _Frameworks and libraries that help implementing and verifying design and archit
 - [jMolecules](https://github.com/xmolecules/jmolecules) - Annotations and interfaces to express design and architecture concepts in code.
 - [jQAssistant](https://github.com/jQAssistant/jqassistant) - Static code analysis with Neo4J-based query language.
 - [Taikai](https://github.com/enofex/taikai) - ArchUnit extension with predefined architecture rules for common Java technologies.
+- [WireDoctor](https://github.com/ddsha441981/wiredoctor) - Zero-intrusion Spring Boot runtime diagnostic for cyclic dependencies, slow beans, and ghost detection with interactive physics-based HTML dashboard and CI regression gates.
 
 ### Artificial Intelligence
 


### PR DESCRIPTION
## Description
Adds WireDoctor, a zero-intrusion Spring Boot runtime diagnostic tool for analyzing architectural health.

## Criteria Met
- ✅ Makes Java/Spring Boot a primary target
- ✅ Noteworthy: Innovative runtime architectural analyzer (no static tool does this)
- ✅ Fills useful niche: Runtime diagnostics + CI gating
- ✅ English documentation: Comprehensive (9 guides, live demo, docs site)
- ✅ Clear licensing: MIT OR Apache-2.0
- ✅ Recently released: v1.0.0 on Maven Central with API freeze

## Links
- GitHub: https://github.com/ddsha441981/wiredoctor
- Maven Central: https://central.sonatype.com/artifact/io.github.ddsha441981/wiredoctor-autoconfigure/1.0.0
- Live Demo: https://ddsha441981.github.io/wiredoctor/sample/test2/wiredoctor-report.html
- Docs: https://ddsha441981.github.io/wiredoctor/

## Why Architecture Category
Detects cyclic bean dependencies (core architecture problem), analyzes bean coupling hotspots, and provides architectural regression gates for CI/CD pipelines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WireDoctor to the Architecture section as a Spring Boot runtime diagnostic that detects cyclic bean dependencies and slow beans, with CI regression gates.

<sup>Written for commit 638e5d73c6e49d729263a5c99349b9b65cda2f74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

