### PR TITLE
Add webforJ to Web Frameworks

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -1259,7 +1259,7 @@ _Frameworks that handle the communication between the layers of a web applicatio
 - [Takes](https://github.com/yegor256/takes) - Opinionated web framework which is built around the concepts of True Object-Oriented Programming and immutability.
 - [tinystruct](https://github.com/tinystruct/tinystruct) - Lightweight, pluggable framework for building Java applications with CLI, HTTP, and modular extension support.
 - [Vaadin](https://vaadin.com) - Full-stack Java platform for building browser applications with server-side components. <!-- github: vaadin/platform, vaadin/flow, vaadin/flow-components, vaadin/spring -->
-- [webforJ](https://github.com/webforj/webforj) - Full-stack platform where the UI is composed and driven from Java on the server, with a component library built on web components, routing, data binding, Spring Boot integration, and publishing of routed views as interactive MCP Apps inside AI hosts.
+- [webforJ](https://github.com/webforj/webforj) - Full-stack platform that composes the UI in Java on the server using a library of web components.
 - [WebForms Core](https://github.com/webforms-core) - A technology for managing HTML tags from the server.
 - [Erupt](https://github.com/erupts/erupt) - Annotation-Driven Low-Code & JPA Visualization.
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -1259,6 +1259,7 @@ _Frameworks that handle the communication between the layers of a web applicatio
 - [Takes](https://github.com/yegor256/takes) - Opinionated web framework which is built around the concepts of True Object-Oriented Programming and immutability.
 - [tinystruct](https://github.com/tinystruct/tinystruct) - Lightweight, pluggable framework for building Java applications with CLI, HTTP, and modular extension support.
 - [Vaadin](https://vaadin.com) - Full-stack Java platform for building browser applications with server-side components. <!-- github: vaadin/platform, vaadin/flow, vaadin/flow-components, vaadin/spring -->
+- [webforJ](https://github.com/webforj/webforj) - Full-stack platform where the UI is composed and driven from Java on the server, with a component library built on web components, routing, data binding, Spring Boot integration, and publishing of routed views as interactive MCP Apps inside AI hosts.
 - [WebForms Core](https://github.com/webforms-core) - A technology for managing HTML tags from the server.
 - [Erupt](https://github.com/erupts/erupt) - Annotation-Driven Low-Code & JPA Visualization.
 


### PR DESCRIPTION
## Suggestion type

- [x] Project
- [ ] Resource

## Checklist

- [x] I searched the list and existing issues for duplicates.
- [x] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x] This pull request contains one suggestion.
- [x] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x] I used the canonical project or resource link.
- [x] The suggestion is current and maintained.
- [x] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x] Licensing is clear and any restrictive terms are disclosed where applicable.

---

Adds [webforJ](https://github.com/webforj/webforj) to Web Frameworks. Full-stack Java platform, MIT licensed, documented at [docs.webforj.com](https://docs.webforj.com/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `webforJ` to Web Frameworks so users can discover a server-driven, full‑stack Java option. Docs-only change with no behavior impact.

- Adds one line to `README_SOURCE.md` under Web Frameworks using the canonical link: https://github.com/webforj/webforj.
- Description highlights server-side UI composition in Java with web components; tone is neutral and concise.

<sup>Written for commit 0d37a42285f9bb6b924465b6f70e9183271f69a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

