### PR TITLE
Add spring-chain-of-responsibility to Utilities

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -1218,6 +1218,7 @@ _Libraries which provide general utility functions._
 - [java-refined](https://github.com/JunggiKim/java-refined) - Zero-dependency refinement types for Java 8+ with type-safe wrappers covering numerics, strings, and collections.
 - [PipelinR](https://github.com/sizovs/pipelinr) - Small utility library for using handlers and commands with pipelines.
 - [Semver4j](https://github.com/semver4j/semver4j) - Lightweight library that helps you handling semantic versioning with different modes.
+- [spring-chain-of-responsibility](https://github.com/evmetatron/spring-chain-of-responsibility) - Autowires Spring Boot beans into a Chain of Responsibility via `@Order` and `@ChainNext`, no manual wiring.
 - [Underscore-java](https://github.com/javadev/underscore-java) - Port of Underscore.js functions.
 - [Zip4j](https://github.com/srikanth-lingala/zip4j) - Reads, writes, encrypts and streams ZIP files.
 


### PR DESCRIPTION
## Suggestion type

- [x] Project
- [ ] Resource

## Checklist

- [x] I searched the list and existing issues for duplicates.
- [x] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x] This pull request contains one suggestion.
- [x] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x] I used the canonical project or resource link.
- [x] The suggestion is current and maintained.
- [x] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x] Licensing is clear and any restrictive terms are disclosed where applicable.

## Why this fits

[spring-chain-of-responsibility](https://github.com/evmetatron/spring-chain-of-responsibility) auto-wires Spring Boot beans implementing a shared interface into a Chain of Responsibility using `@Order` for sequencing and a `@ChainNext` field annotation for the next-link reference — no manual `List<Interface>` collection or sorting in application code, and each handler decides on its own whether to continue the chain (unlike the common manual `@Autowired List<Interface>` + loop approach, which can't express that per-handler). It's a small, focused utility in the same spirit as PipelinR (already listed), published on Maven Central, Apache-2.0 licensed, with tests, Javadoc, and CI across Java 17/21.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `spring-chain-of-responsibility` to the General Utilities list so readers can discover a small Spring Boot Chain of Responsibility helper. Previously the list did not include this utility; now it includes an entry noting auto-wiring via `@Order` and `@ChainNext`.

- Placed under Utilities, alphabetically between `Semver4j` and `Underscore-java`, near `PipelinR`.
- Only `README_SOURCE.md` changed; no code or behavior impact.

<sup>Written for commit 98a7ce121bde254570d246e278c3633a2a5c3840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

