### PR TITLE
Add Ekbatan to ORM

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -813,6 +813,7 @@ _APIs that handle the persistence of objects._
 - [Doma](https://github.com/domaframework/doma) - Database access framework that verifies and generates source code at compile time using annotation processing as well as native SQL templates called two-way SQL.
 - [Ebean](https://github.com/ebean-orm/ebean) - Provides simple and fast data access.
 - [EclipseLink](https://github.com/eclipse-ee4j/eclipselink) - Supports a number of persistence standards: JPA, JAXB, JCA and SDO.
+- [Ekbatan](https://github.com/ekbatan-io/ekbatan) - Modern Java persistence framework for event-driven systems, with an ergonomic outbox that commits state and events in one transaction.
 - [Hibernate](https://github.com/hibernate/hibernate-orm) - Robust and widely used, with an active community.
 - [MyBatis](https://github.com/mybatis/mybatis-3) - Couples objects with stored procedures or SQL statements.
 - [mybatis-dynamic](https://github.com/myacelw/mybatis-dynamic) - Code-first dynamic ORM for MyBatis with runtime schema modification.


### PR DESCRIPTION
Adds [Ekbatan](https://github.com/ekbatan-io/ekbatan) to the **ORM** section.

Ekbatan is a persistence framework that replaces the layer where Spring Data, Hibernate/JPA or hand-rolled JDBC usually sit. Its distinguishing property is that the transactional outbox is part of persistence rather than bolted onto it: a domain model emits its own events when it changes, and committing the model commits those events in the same database transaction. There is no outbox API to call and no dual write to reason about. Debezium (or the in-process handler) then drains the outbox table.

**Why it is distinct from existing entries:**

- vs Hibernate, EclipseLink, Ebean, MyBatis and the rest of the ORM section: those persist objects; none of them make domain events part of the same commit.
- vs standalone outbox libraries: those are add-ons wired into an existing persistence layer, so the application still calls an outbox API. Here the persistence layer *is* the outbox, and application code contains no outbox plumbing.
- No entry currently on the list mentions an outbox, so this fills a gap rather than duplicating one.

**Details:**

- Repo: https://github.com/ekbatan-io/ekbatan
- License: Apache-2.0 (OSI-approved)
- Docs in English: https://ekbatan-io.github.io/ekbatan/
- Java 25; PostgreSQL, MySQL and MariaDB; Spring Boot, Quarkus, Micronaut or plain Java; GraalVM native-image support.

**Placement:** ORM ("APIs that handle the persistence of objects"), inserted alphabetically between EclipseLink and Hibernate. The description ends with a full stop and omits the licence, which the generator renders as an SPDX chip.

**Disclosure:** I am the author of the project.

## Suggestion type

- [x] Project
- [ ] Resource

## Checklist

- [x] I searched the list and existing issues for duplicates.
- [x] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x] This pull request contains one suggestion.
- [x] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x] I used the canonical project or resource link.
- [x] The suggestion is current and maintained.
- [x] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x] Licensing is clear and any restrictive terms are disclosed where applicable.