### PR TITLE
Add Ekbatan to ORM

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -813,6 +813,7 @@ _APIs that handle the persistence of objects._
 - [Doma](https://github.com/domaframework/doma) - Database access framework that verifies and generates source code at compile time using annotation processing as well as native SQL templates called two-way SQL.
 - [Ebean](https://github.com/ebean-orm/ebean) - Provides simple and fast data access.
 - [EclipseLink](https://github.com/eclipse-ee4j/eclipselink) - Supports a number of persistence standards: JPA, JAXB, JCA and SDO.
+- [Ekbatan](https://github.com/ekbatan-io/ekbatan) - Modern Java persistence framework for event-driven systems, with an ergonomic outbox that commits state and events in one transaction.
 - [Hibernate](https://github.com/hibernate/hibernate-orm) - Robust and widely used, with an active community.
 - [MyBatis](https://github.com/mybatis/mybatis-3) - Couples objects with stored procedures or SQL statements.
 - [mybatis-dynamic](https://github.com/myacelw/mybatis-dynamic) - Code-first dynamic ORM for MyBatis with runtime schema modification.


### PR DESCRIPTION
Adds Ekbatan to the ORM section.

Ekbatan is a modern Java persistence framework for event-driven systems, built on top of jOOQ.

A service that publishes domain events usually writes twice, once to the database and once to
the broker, and the two disagree whenever the second write fails. The transactional outbox is
the established answer to that, normally added as a separate library or assembled by hand.

Ekbatan folds the outbox pattern into the persistence layer as a first class citizen, with
three pieces:

- Action: you write one for each unit of business work, you plan the changes you want to apply
  to the db within an Action (insert / update). Action does not immediately write your changes
  into the db, first it accumulates them into a staging area (e.g. WalletMoneyDepositAction,
  OrderRegisterAction).
- ActionPlan: the staging area those changes accumulate on while the action runs. Other than
  accumulating changes, it also accumulates the events attributed to those changes (e.g.
  WalletCreatedEvent, WalletMoneyDepositedEvent).
- ActionExecutor: once the action execution returns it opens one transaction, flushes the plan,
  writes the changes to the tables and accompanying events to the events table, and commits.

State and events land together or neither does.

So the outbox pattern is not new here, it is already established and there are libraries for
it, but no other framework or library currently does it with the same user/developer experience
and ergonomics that Ekbatan provides, which makes it suitable for event-driven systems. Ekbatan
also provides reliable helper mechanisms for publishing the events to event brokers like Kafka
or Pulsar via Debezium plugins, or you can simply use the listen-to-yourself module if you just
want a minimal at-least-once local event handler, without any event broker.

Java 25 on virtual threads, PostgreSQL, MySQL and MariaDB, with Spring Boot, Quarkus, Micronaut
or plain Java.

- Repo: https://github.com/ekbatan-io/ekbatan
- License: Apache-2.0 (OSI-approved)
- Docs in English: https://ekbatan-io.github.io/ekbatan/


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ekbatan to the ORM list in README to surface a modern Java persistence framework for event-driven systems with an outbox that commits state and events in one transaction. This keeps the catalog current for teams needing transactional outbox support.

- **Review notes**
  - Verify the repo link is correct and the description reflects the project.
  - Check alphabetical placement (between EclipseLink and Hibernate) and consistency with list style.

<sup>Written for commit 750b69c70c353f28f127d9b9b05ca0c2e6b47681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

