### PR TITLE
Add LeTrain to game development resources list

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -500,6 +500,7 @@ _Frameworks that support the development of games._
 - [input4j](https://github.com/gurkenlabs/input4j) - Lightweight, cross-platform library for gamepad and joystick input handling.
 - [JBox2D](https://github.com/jbox2d/jbox2d) - Port of the renowned C++ 2D physics engine.
 - [jMonkeyEngine](https://github.com/jMonkeyEngine/jmonkeyengine) - Game engine for modern 3D development.
+- [LeTrain](https://github.com/antoniovazquezaraujo/LeTrain) - Open-source procedural train simulator using Java 17, LibGDX and Lanterna.
 - [libGDX](https://github.com/libgdx/libgdx) - All-round cross-platform, high-level framework.
 - [Litiengine](https://github.com/gurkenlabs/litiengine) - AWT-based, lightweight 2D game engine.
 - [LWJGL](https://github.com/LWJGL/lwjgl3) - Robust framework that abstracts libraries like OpenGL/CL/AL.


### PR DESCRIPTION
## Suggestion type

- [x ] Project
- [ ] Resource

## Checklist

- [x ] I searched the list and existing issues for duplicates.
- [x ] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x ] This pull request contains one suggestion.
- [x ] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x ] I used the canonical project or resource link.
- [x ] The suggestion is current and maintained.
- [x ] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x ] Licensing is clear and any restrictive terms are disclosed where applicable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LeTrain to the Game Development → Frameworks list to broaden coverage of active Java game projects. This highlights an open-source procedural train simulator built with Java 17, LibGDX, and Lanterna.

- Single-line addition in `README_SOURCE.md` under the Frameworks subsection.
- Uses the canonical GitHub link and a concise description; no other edits.
- No build or runtime impact; `README.md` will reflect this after the next generation step.

<sup>Written for commit 2604024a3761210d9411bd8eac81c5e86ec16fc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

