### PR TITLE
Add Ujorm to ORM

### DIFF
--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -824,6 +824,7 @@ _APIs that handle the persistence of objects._
 - [ObjectiveSql](https://github.com/braisdom/ObjectiveSql) - ActiveRecord ORM for rapid development and convention over configuration.
 - [Permazen](https://github.com/permazen/permazen) - Language-natural persistence layer.
 - [SimpleFlatMapper](https://github.com/arnaudroger/SimpleFlatMapper) - Simple database and CSV mapper.
+- [Ujorm](https://github.com/pponec/ujorm) - Maps rows to JavaBeans or Java records with no third-party runtime dependencies, deliberately omitting lazy loading, 1:M collections and transaction management.
 
 ### PaaS
 


### PR DESCRIPTION
Adds [Ujorm](https://github.com/pponec/ujorm) to the **ORM** section.

Ujorm is a JDBC mapping library for Java 17+. It maps rows to mutable JavaBeans or immutable
records through typed keys generated at compile time by an annotation processor, and offers a
query DSL in which the compiler checks both the referenced columns and the type of every value
placed into a condition. Native SQL with named parameter binding is available for cases the DSL
does not cover.

**Why it is distinct from existing entries:**

- Its scope is restricted on purpose: no lazy loading, no 1:M collection mapping, no SQL dialect
  abstraction and no transaction management. The README states these as design rules rather than
  gaps to be closed later, which is what sets the library apart from the full ORMs in this section.
- vs **Doma**: Doma also uses annotation processing for compile-time verification, but targets
  SQL templates and DAO interfaces. Ujorm generates typed key objects that are used directly as
  a query DSL and as the mapping metadata, and it performs no code generation for DAOs.
- vs **Ebean**, **Hibernate**, **EclipseLink**: those manage an entity lifecycle and a persistence
  context. Ujorm treats entities as stateless data carriers and leaves transactions to the caller's
  `java.sql.Connection`.
- It has no third-party runtime dependencies. In the published POM of `org.ujorm:ujo-orm:3.0.5`,
  `jakarta.persistence-api` and the annotation processor are `provided` and
  `org.jetbrains:annotations` is `optional`; the runtime artifacts total roughly 0.27 MB.

**Details:**

- Repo: https://github.com/pponec/ujorm
- License: Apache-2.0
- Documentation in English: https://github.com/pponec/ujorm#readme
- Java 17+; released on Maven Central as `org.ujorm:ujo-orm`, currently 3.0.5 (2026-08-17).

**Placement:** ORM ("APIs that handle the persistence of objects"), appended at the end of the
section, after SimpleFlatMapper, in ascending alphabetical order.

**Disclosure:** I am the author of the project.

## Suggestion type

- [x] Project
- [ ] Resource

## Checklist

- [x] I searched the list and existing issues for duplicates.
- [x] I changed `README_SOURCE.md`, not the generated `README.md`.
- [x] This pull request contains one suggestion.
- [x] The suggestion is relevant to Java or the JVM and fits its chosen category.
- [x] I used the canonical project or resource link.
- [x] The suggestion is current and maintained.
- [x] The concise, neutral description explains its distinguishing value and ends with punctuation.
- [x] Licensing is clear and any restrictive terms are disclosed where applicable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ujorm to the ORM section to represent a lightweight JDBC mapping library for Java 17+. Unlike full ORMs, it uses compile-time typed keys/DSL and intentionally omits lazy loading, 1:M collections, dialect abstraction, and transaction management; it has no third-party runtime dependencies.

- Placement: ORM section after SimpleFlatMapper in ascending alphabetical order; updates `README_SOURCE.md` only.
- Content checks: neutral, concise description with repo link; Apache-2.0; Java 17+; Maven `org.ujorm:ujo-orm`.

<sup>Written for commit f8e6eee1f71625b6ef934620653f39401b8f4ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akullpp/awesome-java/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

